### PR TITLE
Fix drag-and-drop file open corrupting backupFilename

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -7,7 +7,6 @@
 #include <QProcess>
 #include "passworddialog.h"
 #include "cryptoutils.h"
-#include <QFileOpenEvent>
 
 MainWindow::MainWindow(QWidget *parent) :
   QMainWindow(parent),
@@ -229,27 +228,18 @@ void MainWindow::showInGraphicalShell(const QString &pathIn)
 
 void MainWindow::openBackupFile(const QString &filename)
 {
-    backupFilename = filename;
-    QFileInfo fileInfo(backupFilename);
+    QFileInfo fileInfo(filename);
 
     if (!fileInfo.isReadable()) {
         QMessageBox::warning(this, tr("Unable to open file"),
-                           tr("Unable to open file: %1").arg(backupFilename),
+                           tr("Unable to open file: %1").arg(filename),
                            QMessageBox::StandardButton::Ok);
         return;
     }
 
+    backupFilename = filename;
     ui->dropZone->setFileName(fileInfo.fileName());
     ui->extractBackupButton->setEnabled(true);
     ui->clearButton->setVisible(true);
 }
 
-bool MainWindow::event(QEvent *event)
-{
-    if (event->type() == QEvent::FileOpen) {
-        QFileOpenEvent *openEvent = static_cast<QFileOpenEvent *>(event);
-        openBackupFile(openEvent->file());
-        return true;
-    }
-    return QMainWindow::event(event);
-}

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -16,8 +16,6 @@ class MainWindow : public QMainWindow
   public:
     explicit MainWindow(QWidget *parent = nullptr);
     ~MainWindow();
-    bool event(QEvent *event) override;
-
   public slots:
     void openBackup();
     void openBackupFile(const QString &filename);


### PR DESCRIPTION
On macOS, dragging a file onto the window could trigger both the DropOverlay drop handler and a QEvent::FileOpen via AppDelegate, potentially with different file paths. Because openBackupFile() set backupFilename before validating the file, a stale or unreadable path from the FileOpen event could silently overwrite backupFilename while the UI continued to display the correct filename from the drop.

Move backupFilename assignment after the isReadable() check so invalid paths never corrupt state. Remove the duplicate QEvent::FileOpen handler from MainWindow::event() since AppDelegate already handles it.