### PR TITLE
ci: upload build artifacts on PRs and post download links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,13 @@ jobs:
           cd tests
           ./tst_qtraktor
 
+      - name: Upload build artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Traktor-linux-x86_64
+          path: Traktor
+
       - name: Run clazy (Qt-specific linting)
         if: github.event_name == 'pull_request'
         continue-on-error: true
@@ -122,6 +129,21 @@ jobs:
         run: |
           cd tests
           ./tst_qtraktor
+
+      - name: Bundle app for testing
+        if: github.event_name == 'pull_request'
+        run: |
+          export PATH="$(brew --prefix qt@5)/bin:$PATH"
+          macdeployqt Traktor.app
+          codesign --force --deep --sign - Traktor.app
+          tar -cf Traktor.app.tar Traktor.app
+
+      - name: Upload build artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Traktor-macOS
+          path: Traktor.app.tar
 
   build-test-windows:
     name: Build & Test (Windows)
@@ -182,3 +204,65 @@ jobs:
         run: |
           cd tests
           release\tst_qtraktor.exe
+
+      - name: Bundle app for testing
+        if: github.event_name == 'pull_request'
+        shell: pwsh
+        run: windeployqt release\Traktor.exe
+
+      - name: Upload build artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: Traktor-windows-x64
+          path: release\
+
+  pr-artifacts-comment:
+    name: PR Build Artifacts
+    if: github.event_name == 'pull_request'
+    needs: [build-test-linux, build-test-macos, build-test-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post artifact links to PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runId = context.runId;
+            const repo = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const url = `https://github.com/${repo.owner}/${repo.repo}/actions/runs/${runId}`;
+
+            const body = `## Build Artifacts
+
+            | Platform | Download |
+            |----------|----------|
+            | Linux (x86_64) | [Traktor-linux-x86_64](${url}#artifacts) |
+            | macOS (Apple Silicon) | [Traktor-macOS](${url}#artifacts) |
+            | Windows (x64) | [Traktor-windows-x64](${url}#artifacts) |
+
+            Built from ${context.sha.substring(0, 7)}. Artifacts expire after 90 days.`.replace(/            /g, '');
+
+            // Find and update existing comment, or create new one
+            const comments = await github.rest.issues.listComments({
+              ...repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.data.find(c =>
+              c.user.type === 'Bot' && c.body.includes('## Build Artifacts')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...repo,
+                issue_number: prNumber,
+                body,
+              });
+            }


### PR DESCRIPTION
## Summary

- Upload Traktor binaries as GitHub Actions artifacts on every PR
- Post a comment on the PR with download links for all three platforms
- macOS uses `macdeployqt` to bundle Qt frameworks so the .app is runnable
- Windows uses `windeployqt` to bundle Qt DLLs
- Linux uploads the raw binary
- Comment updates on force-push (doesn't create duplicates)
- Artifacts only uploaded on PRs, not on push to master

## Test plan

- [ ] This PR itself should get a "Build Artifacts" comment with download links
- [ ] Artifacts are downloadable from the Actions run page