### PR TITLE
docs: add privacy policy and terms of use

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -256,6 +256,8 @@
       Open source under <a href="https://github.com/servmask/Qtraktor/blob/master/LICENSE">GPLv3</a>.
       Built with C++ and Qt.
       <a href="https://github.com/servmask/Qtraktor">GitHub</a>
+      &middot; <a href="privacy.html">Privacy</a>
+      &middot; <a href="terms.html">Terms</a>
     </div>
   </div>
 

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy - Traktor</title>
+  <link rel="icon" type="image/png" href="favicon.png">
+  <style>
+    :root { --bg: #0b0f13; --surface: #151b23; --border: #2a3140; --text: #e6edf3; --text-dim: #8b949e; --accent: #4c8ef7; }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; }
+    .container { max-width: 640px; margin: 0 auto; padding: 56px 24px 40px; }
+    .back { color: var(--accent); text-decoration: none; font-size: 0.88em; display: inline-block; margin-bottom: 32px; }
+    .back:hover { text-decoration: underline; }
+    h1 { font-size: 1.8em; font-weight: 700; margin-bottom: 8px; }
+    .updated { color: var(--text-dim); font-size: 0.85em; margin-bottom: 32px; }
+    h2 { font-size: 1.15em; font-weight: 600; margin-top: 32px; margin-bottom: 10px; }
+    p, ul { margin-bottom: 16px; color: var(--text-dim); }
+    ul { padding-left: 20px; }
+    li { margin-bottom: 6px; }
+    strong { color: var(--text); }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .footer { text-align: center; color: var(--text-dim); font-size: 0.76em; padding-top: 24px; margin-top: 48px; border-top: 1px solid var(--border); }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <a href="./" class="back">&larr; Back to Traktor</a>
+    <h1>Privacy Policy</h1>
+    <p class="updated">Last updated: March 28, 2026</p>
+
+    <h2>The short version</h2>
+    <p><strong>Traktor does not collect, store, transmit, or share any data. Period.</strong></p>
+
+    <h2>What Traktor does</h2>
+    <p>Traktor is a local desktop application that extracts WordPress .wpress backup files on your computer. It reads a file from your disk, extracts its contents to a folder on your disk, and that's it.</p>
+
+    <h2>Data collection</h2>
+    <p>Traktor collects <strong>no data whatsoever</strong>. Specifically:</p>
+    <ul>
+      <li><strong>No analytics or telemetry.</strong> We do not track how you use the app.</li>
+      <li><strong>No network requests.</strong> Traktor never connects to the internet. It works entirely offline.</li>
+      <li><strong>No accounts or registration.</strong> There is no sign-up, login, or user profile.</li>
+      <li><strong>No crash reports.</strong> If the app crashes, nothing is sent anywhere.</li>
+      <li><strong>No cookies or tracking.</strong> The app has no web components.</li>
+    </ul>
+
+    <h2>Files you process</h2>
+    <p>The .wpress files you open with Traktor are read locally on your machine. The extracted contents are written to your local disk. No file data ever leaves your computer.</p>
+
+    <h2>Settings</h2>
+    <p>Traktor stores minimal preferences locally on your machine (last-used directory, window position) using your operating system's standard settings storage (macOS Preferences, Windows Registry, Linux config files). These never leave your device.</p>
+
+    <h2>This website</h2>
+    <p>This website (traktor.wp-migration.com) is hosted on GitHub Pages. GitHub may collect standard web server logs (IP addresses, browser type) as described in <a href="https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement">GitHub's Privacy Statement</a>. We do not add any additional tracking, analytics, or cookies to this website.</p>
+
+    <h2>Open source</h2>
+    <p>Traktor is open source under the GPLv3 license. You can <a href="https://github.com/servmask/Qtraktor">inspect the source code</a> to verify every claim on this page.</p>
+
+    <h2>Contact</h2>
+    <p>Questions about this policy? Open an issue on <a href="https://github.com/servmask/Qtraktor/issues">GitHub</a>.</p>
+
+    <div class="footer">Traktor is open source software by <a href="https://github.com/servmask">ServMask</a>.</div>
+  </div>
+</body>
+</html>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Use - Traktor</title>
+  <link rel="icon" type="image/png" href="favicon.png">
+  <style>
+    :root { --bg: #0b0f13; --surface: #151b23; --border: #2a3140; --text: #e6edf3; --text-dim: #8b949e; --accent: #4c8ef7; }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; }
+    .container { max-width: 640px; margin: 0 auto; padding: 56px 24px 40px; }
+    .back { color: var(--accent); text-decoration: none; font-size: 0.88em; display: inline-block; margin-bottom: 32px; }
+    .back:hover { text-decoration: underline; }
+    h1 { font-size: 1.8em; font-weight: 700; margin-bottom: 8px; }
+    .updated { color: var(--text-dim); font-size: 0.85em; margin-bottom: 32px; }
+    h2 { font-size: 1.15em; font-weight: 600; margin-top: 32px; margin-bottom: 10px; }
+    p, ul { margin-bottom: 16px; color: var(--text-dim); }
+    ul { padding-left: 20px; }
+    li { margin-bottom: 6px; }
+    strong { color: var(--text); }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .footer { text-align: center; color: var(--text-dim); font-size: 0.76em; padding-top: 24px; margin-top: 48px; border-top: 1px solid var(--border); }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <a href="./" class="back">&larr; Back to Traktor</a>
+    <h1>Terms of Use</h1>
+    <p class="updated">Last updated: March 28, 2026</p>
+
+    <h2>License</h2>
+    <p>Traktor is free, open source software distributed under the <a href="https://www.gnu.org/licenses/gpl-3.0.html">GNU General Public License v3.0</a> (GPLv3). You may use, copy, modify, and distribute the software under the terms of that license.</p>
+
+    <h2>What you can do</h2>
+    <ul>
+      <li>Use Traktor for any purpose, personal or commercial</li>
+      <li>Modify the source code</li>
+      <li>Distribute copies</li>
+      <li>Distribute your modified versions (under the same GPLv3 license)</li>
+    </ul>
+
+    <h2>No warranty</h2>
+    <p>Traktor is provided <strong>"as is"</strong> without warranty of any kind, express or implied. The authors are not liable for any damages arising from the use of this software. This includes but is not limited to:</p>
+    <ul>
+      <li>Data loss or corruption during extraction</li>
+      <li>Inability to extract a particular .wpress file</li>
+      <li>Incompatibility with your operating system or hardware</li>
+    </ul>
+    <p>See Section 15 and 16 of the <a href="https://www.gnu.org/licenses/gpl-3.0.html">GPLv3</a> for the full warranty disclaimer.</p>
+
+    <h2>Your files</h2>
+    <p>You are responsible for the files you process with Traktor. The software extracts .wpress archives as-is. We make no guarantees about the contents of any archive you open.</p>
+
+    <h2>Security</h2>
+    <p>While we take security seriously (the code is open source and reviewed), no software is guaranteed to be free of vulnerabilities. If you discover a security issue, please report it responsibly via <a href="https://github.com/servmask/Qtraktor/security/advisories/new">GitHub's private vulnerability reporting</a>.</p>
+
+    <h2>This website</h2>
+    <p>This website provides download links to Traktor releases hosted on GitHub. We link directly to GitHub Releases. We do not host binaries ourselves, repackage the software, or bundle additional software with it.</p>
+
+    <h2>Changes</h2>
+    <p>We may update these terms as the software evolves. Changes will be posted on this page with an updated date. Continued use of the software constitutes acceptance of the current terms.</p>
+
+    <h2>Contact</h2>
+    <p>Questions about these terms? Open an issue on <a href="https://github.com/servmask/Qtraktor/issues">GitHub</a>.</p>
+
+    <div class="footer">Traktor is open source software by <a href="https://github.com/servmask">ServMask</a>.</div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Add `docs/privacy.html` and `docs/terms.html`
- Add Privacy and Terms links to download page footer
- Privacy: no data collection, no network requests, no telemetry, no accounts
- Terms: GPLv3, no warranty, standard OSS liability disclaimer

## Test plan

- [ ] Privacy page loads at /privacy.html
- [ ] Terms page loads at /terms.html
- [ ] Footer links work on main download page
- [ ] Back links return to main page