### PR TITLE
fix: keep QtDBus.framework in macOS bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,6 @@ jobs:
           # Traktor is a pure Widgets app with zero QML, SVG, GIF, or network use.
           rm -rf build/Traktor.app/Contents/Frameworks/QtQml*.framework \
                  build/Traktor.app/Contents/Frameworks/QtQuick*.framework \
-                 build/Traktor.app/Contents/Frameworks/QtDBus.framework \
                  build/Traktor.app/Contents/Frameworks/QtSvg.framework
           rm -f build/Traktor.app/Contents/PlugIns/iconengines/libqsvgicon.dylib \
                 build/Traktor.app/Contents/PlugIns/imageformats/libqgif.dylib \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
           # Traktor is a pure Widgets app with zero QML, SVG, GIF, or network use.
           rm -rf build/Traktor.app/Contents/Frameworks/QtQml*.framework \
                  build/Traktor.app/Contents/Frameworks/QtQuick*.framework \
-                 build/Traktor.app/Contents/Frameworks/QtDBus.framework \
                  build/Traktor.app/Contents/Frameworks/QtSvg.framework
           rm -f build/Traktor.app/Contents/PlugIns/iconengines/libqsvgicon.dylib \
                 build/Traktor.app/Contents/PlugIns/imageformats/libqgif.dylib \


### PR DESCRIPTION
## Summary

- QtGui.framework depends on QtDBus.framework at runtime (Qt 6 uses D-Bus for accessibility on macOS)
- The bundle stripping in #26 removed QtDBus, causing `dyld: Library not loaded` crash on launch
- This removes QtDBus from the strip list while keeping all other unused framework removals

## Test plan

- [ ] macOS app launches after PKG install
- [ ] `traktor -h` works from CLI