### PR TITLE
fix: remove extra escaping in Homebrew Cask URL template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -393,12 +393,12 @@ jobs:
             version \"%s\"
             sha256 \"%s\"
 
-            url \"https://github.com/servmask/Qtraktor/releases/download/v#\\{version\\}/Traktor-v#\\{version\\}.pkg\"
+            url \"https://github.com/servmask/Qtraktor/releases/download/v#{version}/Traktor-v#{version}.pkg\"
             name \"Traktor\"
             desc \"Extract WordPress .wpress backup files with CLI and MCP server\"
             homepage \"https://github.com/servmask/Qtraktor\"
 
-            pkg \"Traktor-v#\\{version\\}.pkg\"
+            pkg \"Traktor-v#{version}.pkg\"
 
             caveats <<~EOS
               To register Traktor with your AI coding agents (Claude Code, Gemini CLI):


### PR DESCRIPTION
## What does this PR do?

Fixes the Homebrew Cask `url` and `pkg` stanzas by removing extra backslash escaping of `{version}` in the Python template inside `release.yml`.

The Python script used `#\\{version\\}` which, after shell + Python processing, produced `#\{version\}` in the generated `traktor.rb` — invalid Ruby syntax. The fix uses `#{version}` which passes through both layers unchanged, producing valid Ruby string interpolation.

## Related Issue

Fixes #34

## Checklist

- [x] PR title follows conventional commit format (`feat:`, `fix:`, `docs:`, etc.)
- [x] Code compiles without warnings on at least one platform
- [x] Tests pass locally
- [x] New code follows existing style
- [ ] Added tests for new functionality (if applicable) — N/A, CI workflow change

## Notes

The existing `Casks/traktor.rb` in `servmask/homebrew-traktor` is already broken and should be fixed directly so `brew install` works before the next release.