### PR TITLE
feat: add hybrid CLI/GUI mode (Linux dlopen split + Windows console s…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Traktor-linux-x86_64
-          path: build/Traktor
+          path: |
+            build/Traktor
+            build/libtraktor-core.so
+            build/libtraktor-gui.so
 
   build-test-macos:
     name: Build & Test (macOS)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,11 +318,16 @@ jobs:
           mkdir -p AppDir/usr/share/mime/packages
           cp wpress.xml AppDir/usr/share/mime/packages/
 
-          # Build AppImage
+          # Build AppImage. Pass the GUI plugin (libtraktor-gui.so) as
+          # --library so linuxdeploy-plugin-qt scans it for Qt deps and
+          # bundles Qt6Gui/Widgets/Network. The main executable links
+          # only Qt6::Core + libdl on Linux (CLI works without libGL).
           export QMAKE="$QT_ROOT_DIR/bin/qmake"
           ./linuxdeploy-x86_64.AppImage \
             --appdir AppDir \
             --executable build/Traktor \
+            --library build/libtraktor-core.so \
+            --library build/libtraktor-gui.so \
             --desktop-file traktor.desktop \
             --icon-file icons/traktor.png \
             --plugin qt \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ if(NOT MSVC)
 else()
     target_compile_options(bzip2 PRIVATE /w)
 endif()
+# Linux SHARED libraries (libtraktor-core.so) link bzip2; needs PIC.
+set_target_properties(bzip2 PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Application sources
 set(APP_SOURCES
@@ -79,19 +81,121 @@ else()
     list(APPEND APP_SOURCES src/dockprogress_stub.cpp)
 endif()
 
-qt_add_executable(Traktor ${APP_SOURCES} ${APP_HEADERS} ${APP_FORMS})
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    # ── Hybrid CLI/GUI build (Linux only) ──────────────────────────────────
+    # The executable links Qt6::Core only — no libGL, no QtGui, no
+    # QtWidgets in DT_NEEDED. The GUI lives in libtraktor-gui.so which
+    # main.cpp dlopen()s at runtime when probes for $DISPLAY, libGL.so.1
+    # and the plugin itself succeed. On a minimal container the binary
+    # stays in CLI mode (no loader errors before main() runs).
+    #
+    # Layout:
+    #   bin/Traktor              executable (only Qt6::Core + libdl)
+    #   lib/libtraktor-core.so   shared core (BackupFile, CLI handlers, MCP, ...)
+    #   lib/libtraktor-gui.so    dlopen'd GUI plugin (Widgets, MainWindow, ...)
+    set(CORE_SOURCES
+        src/backupfile.cpp
+        src/cryptoutils.cpp
+        src/extractionworker.cpp
+        src/clihandler.cpp
+        src/mcpserver.cpp
+        src/installcli.cpp
+        src/agentconfig.cpp
+    )
+    set(CORE_HEADERS
+        src/backupfile.h
+        src/cryptoutils.h
+        src/extractionworker.h
+        src/clihandler.h
+        src/mcpserver.h
+        src/installcli.h
+        src/agentconfig.h
+    )
+    add_library(traktor-core SHARED ${CORE_SOURCES} ${CORE_HEADERS})
+    target_include_directories(traktor-core PUBLIC src)
+    target_link_libraries(traktor-core PUBLIC
+        Qt6::Core
+        OpenSSL::SSL
+        OpenSSL::Crypto
+        ZLIB::ZLIB
+        bzip2
+    )
+    set_target_properties(traktor-core PROPERTIES
+        OUTPUT_NAME "traktor-core"
+        BUILD_RPATH "$ORIGIN"
+        INSTALL_RPATH "$ORIGIN"
+    )
 
-target_include_directories(Traktor PRIVATE src)
+    set(GUI_SOURCES
+        src/mainwindow.cpp
+        src/setupdialog.cpp
+        src/passworddialog.cpp
+        src/autoextractor.cpp
+        src/progresswindow.cpp
+        src/dropoverlay.cpp
+        src/appdelegate.cpp
+        src/dockprogress_stub.cpp
+        src/gui_entry.cpp
+    )
+    set(GUI_HEADERS
+        src/mainwindow.h
+        src/setupdialog.h
+        src/passworddialog.h
+        src/autoextractor.h
+        src/progresswindow.h
+        src/dropoverlay.h
+        src/appdelegate.h
+        src/dockprogress.h
+    )
+    qt_add_library(traktor-gui SHARED
+        ${GUI_SOURCES} ${GUI_HEADERS} src/mainwindow.ui
+    )
+    target_link_libraries(traktor-gui PRIVATE
+        traktor-core
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Widgets
+        Qt6::Network
+    )
+    set_target_properties(traktor-gui PROPERTIES
+        OUTPUT_NAME "traktor-gui"
+        BUILD_RPATH "$ORIGIN"
+        INSTALL_RPATH "$ORIGIN"
+    )
 
-target_link_libraries(Traktor PRIVATE
-    Qt6::Core
-    Qt6::Gui
-    Qt6::Widgets
-    Qt6::Network
-    OpenSSL::SSL
-    OpenSSL::Crypto
-    ZLIB::ZLIB
-    bzip2
+    add_executable(Traktor src/main.cpp)
+    target_link_libraries(Traktor PRIVATE
+        traktor-core
+        ${CMAKE_DL_LIBS}
+    )
+    # $ORIGIN = build dir (libs side-by-side); $ORIGIN/../lib = installed layout.
+    set_target_properties(Traktor PROPERTIES
+        BUILD_RPATH "$ORIGIN;$ORIGIN/../lib"
+        INSTALL_RPATH "$ORIGIN/../lib"
+    )
+
+    install(TARGETS Traktor RUNTIME DESTINATION bin)
+    install(TARGETS traktor-core traktor-gui LIBRARY DESTINATION lib)
+else()
+    qt_add_executable(Traktor ${APP_SOURCES} ${APP_HEADERS} ${APP_FORMS})
+
+    target_include_directories(Traktor PRIVATE src)
+
+    target_link_libraries(Traktor PRIVATE
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Widgets
+        Qt6::Network
+        OpenSSL::SSL
+        OpenSSL::Crypto
+        ZLIB::ZLIB
+        bzip2
+    )
+endif()
+
+# Project version is consumed by main.cpp's --version handler on every platform.
+target_compile_definitions(Traktor PRIVATE
+    PROJECT_VERSION_STR="${PROJECT_VERSION}"
 )
 
 # macOS bundle configuration
@@ -123,7 +227,10 @@ endif()
 
 # Windows configuration
 if(WIN32)
-    set_target_properties(Traktor PROPERTIES WIN32_EXECUTABLE TRUE)
+    # Console subsystem (WIN32_EXECUTABLE FALSE) so CLI subcommands print
+    # reliably to any shell. main.cpp hides and detaches the console
+    # before the GUI event loop starts so GUI launches still look clean.
+    set_target_properties(Traktor PROPERTIES WIN32_EXECUTABLE FALSE)
     target_sources(Traktor PRIVATE icons/traktor.rc)
 endif()
 

--- a/src/clihandler.cpp
+++ b/src/clihandler.cpp
@@ -1,6 +1,8 @@
 #include "clihandler.h"
 #include "backupfile.h"
 #include "cryptoutils.h"
+#include "installcli.h"
+#include "mcpserver.h"
 #include <QCommandLineParser>
 #include <QCoreApplication>
 #include <QDir>
@@ -9,6 +11,8 @@
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QString>
+#include <QStringList>
 #include <cstdio>
 
 #ifdef Q_OS_WIN
@@ -483,5 +487,225 @@ int cmdVerify(int /*argc*/, char * /*argv*/[])
     if (!allPassed) {
         return 4;
     }
+    return 0;
+}
+
+// ── global help ─────────────────────────────────────────────────────────────
+
+void printGlobalHelp()
+{
+    fprintf(stdout, "Qtraktor - All-in-One WP Migration and Backup extractor\n"
+                    "\n"
+                    "Usage: traktor <command> [options] <archive>\n"
+                    "\n"
+                    "Commands:\n"
+                    "  list        List contents of a .wpress archive\n"
+                    "  info        Show archive metadata (format, encryption, file count)\n"
+                    "  extract     Extract all files from a .wpress archive\n"
+                    "  cat         Stream a single file from an archive to stdout\n"
+                    "  verify      Verify archive integrity (CRC32)\n"
+                    "  mcp         Start MCP server for AI agent integration\n"
+                    "  install-cli Install command-line tool to system PATH (macOS)\n"
+                    "  uninstall   Remove CLI, AI agent integrations, and settings\n"
+                    "\n"
+                    "Global options:\n"
+                    "  -p, --password <pw>   Password for encrypted archives\n"
+                    "                        (or set TRAKTOR_PASSWORD environment variable)\n"
+                    "  --json                Machine-readable JSON output\n"
+                    "  -q, --quiet           Suppress progress output\n"
+                    "  -h, --help            Show this help\n"
+                    "  -v, --version         Show version\n"
+                    "\n"
+#ifdef __linux__
+                    "Linux GUI options:\n"
+                    "  --gui                 Force GUI mode (fail loudly if GUI libs missing)\n"
+                    "  --cli, --no-gui       Force CLI mode (skip GUI auto-detect)\n"
+                    "\n"
+#endif
+                    "Legacy mode:\n"
+                    "  traktor --source <file> --destination <dir> [-p password]\n"
+                    "\n"
+                    "Exit codes:\n"
+                    "  0  Success\n"
+                    "  1  General error (I/O, permissions, usage)\n"
+                    "  2  Invalid or corrupted archive\n"
+                    "  3  Wrong or missing password\n"
+                    "  4  CRC32 verification failure\n"
+                    "\n"
+                    "Examples:\n"
+                    "  traktor list backup.wpress\n"
+                    "  traktor list --json backup.wpress | jq '.path'\n"
+                    "  traktor cat backup.wpress wp-config.php | grep DB_PASSWORD\n"
+                    "  traktor verify --json backup.wpress\n"
+                    "  traktor extract backup.wpress ./output/\n");
+    fflush(stdout);
+}
+
+// ── subcommand dispatch ─────────────────────────────────────────────────────
+
+int dispatchCliSubcommand(int argc, char *argv[], bool *handled)
+{
+    *handled = false;
+    if (argc < 2) {
+        return 0;
+    }
+
+    const QString sub = QString::fromLocal8Bit(argv[1]);
+
+    auto run = [&](auto fn) {
+        QCoreApplication app(argc, argv);
+        QCoreApplication::setApplicationName("traktor");
+        return fn();
+    };
+
+    if (sub == "list") {
+        *handled = true;
+        return run([&] { return cmdList(argc, argv); });
+    }
+    if (sub == "info") {
+        *handled = true;
+        return run([&] { return cmdInfo(argc, argv); });
+    }
+    if (sub == "extract") {
+        *handled = true;
+        return run([&] { return cmdExtract(argc, argv); });
+    }
+    if (sub == "cat") {
+        *handled = true;
+        return run([&] { return cmdCat(argc, argv); });
+    }
+    if (sub == "verify") {
+        *handled = true;
+        return run([&] { return cmdVerify(argc, argv); });
+    }
+    if (sub == "mcp") {
+        *handled = true;
+        return run([&] { return cmdMcp(); });
+    }
+    if (sub == "install-cli") {
+        *handled = true;
+        return run([&] { return cmdInstallCli(); });
+    }
+    if (sub == "uninstall") {
+        *handled = true;
+        return run([&] { return cmdUninstall(); });
+    }
+
+    return 0;
+}
+
+// ── legacy --source / --destination extract ─────────────────────────────────
+
+static void printLegacyProgress(float percent)
+{
+    int filled = static_cast<int>(percent / 5.0f);
+    fprintf(stdout, "\r[");
+    for (int i = 0; i < 20; i++)
+        fputc(i < filled ? '#' : ' ', stdout);
+    fprintf(stdout, "] %3d%%", static_cast<int>(percent));
+    fflush(stdout);
+}
+
+int cmdLegacyExtract(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+    QCoreApplication::setApplicationName("traktor");
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription("Qtraktor - legacy CLI extract mode");
+    parser.addHelpOption();
+
+    QCommandLineOption sourceOption(QStringList() << "s" << "source", "Backup file to open (.wpress)", "source");
+    parser.addOption(sourceOption);
+    QCommandLineOption destinationOption(QStringList() << "d" << "destination", "Directory to extract the backup into",
+                                         "destination");
+    parser.addOption(destinationOption);
+    QCommandLineOption passwordOption(QStringList() << "p" << "password", "Password for encrypted backup", "password");
+    parser.addOption(passwordOption);
+
+    parser.process(app);
+
+    const QString source = parser.value(sourceOption);
+    const QString destination = parser.value(destinationOption);
+    const QString password = parser.value(passwordOption);
+
+    if (source.isEmpty() || destination.isEmpty()) {
+        fprintf(stderr, "Error: legacy mode requires both --source and --destination\n");
+        return 1;
+    }
+
+    QFileInfo fileInfo(source);
+    if (!fileInfo.isReadable()) {
+        fprintf(stderr, "Error: cannot read file: %s\n", source.toLocal8Bit().constData());
+        return 1;
+    }
+
+    QDir extractTo(destination + "/" + fileInfo.baseName());
+    if (!QDir().mkpath(extractTo.path())) {
+        fprintf(stderr, "Error: cannot create directory: %s\n", extractTo.path().toLocal8Bit().constData());
+        return 1;
+    }
+
+    BackupFile configChecker(source);
+    bool needsPassword = false;
+    CompressionType compressionType = COMPRESSION_NONE;
+
+    if (configChecker.open(QIODevice::ReadOnly)) {
+        if (configChecker.isValid()) {
+            needsPassword = configChecker.isEncryptedFile();
+            compressionType = configChecker.getCompressionType();
+        }
+        configChecker.close();
+    }
+
+    QString filePassword = password;
+    if (filePassword.isEmpty())
+        filePassword = qEnvironmentVariable("TRAKTOR_PASSWORD");
+    if (needsPassword && filePassword.isEmpty()) {
+        fprintf(stderr, "Error: backup is encrypted - provide a password with -p\n");
+        extractTo.removeRecursively();
+        return 1;
+    }
+
+    BackupFile backupFile(source, filePassword);
+    if (!backupFile.open(QIODevice::ReadOnly)) {
+        fprintf(stderr, "Error: cannot open file: %s\n", source.toLocal8Bit().constData());
+        extractTo.removeRecursively();
+        return 1;
+    }
+    backupFile.setConfig(needsPassword, compressionType);
+
+    if (!backupFile.isValid()) {
+        fprintf(stderr, "Error: backup file is corrupted (missing end-of-file marker)\n");
+        backupFile.close();
+        extractTo.removeRecursively();
+        return 1;
+    }
+
+    fprintf(stdout, "File : %s\n", fileInfo.fileName().toLocal8Bit().constData());
+    fprintf(stdout, "To   : %s\n", extractTo.path().toLocal8Bit().constData());
+    fflush(stdout);
+
+    QObject::connect(&backupFile, &BackupFile::progress, printLegacyProgress);
+
+    QObject::connect(&backupFile, &BackupFile::error, [](const QString &msg) {
+        fprintf(stderr, "\nError: %s\n", msg.toLocal8Bit().constData());
+        fflush(stderr);
+    });
+
+    const bool ok = backupFile.extract(extractTo);
+    backupFile.close();
+
+    fprintf(stdout, "\n");
+    fflush(stdout);
+
+    if (!ok) {
+        fprintf(stderr, "Extraction failed.\n");
+        extractTo.removeRecursively();
+        return 1;
+    }
+
+    fprintf(stdout, "Done. Extracted to: %s\n", extractTo.path().toLocal8Bit().constData());
+    fflush(stdout);
     return 0;
 }

--- a/src/clihandler.cpp
+++ b/src/clihandler.cpp
@@ -641,10 +641,19 @@ int cmdLegacyExtract(int argc, char *argv[])
     }
 
     QDir extractTo(destination + "/" + fileInfo.baseName());
+    // mkpath() returns true when the directory already exists, so on error
+    // paths we must only removeRecursively() the dir if WE created it —
+    // otherwise we'd silently wipe a user's pre-existing directory (e.g. a
+    // prior successful extraction at the same destination).
+    const bool dirPreExisted = QFileInfo::exists(extractTo.path());
     if (!QDir().mkpath(extractTo.path())) {
         fprintf(stderr, "Error: cannot create directory: %s\n", extractTo.path().toLocal8Bit().constData());
         return 1;
     }
+    auto cleanupIfCreated = [&] {
+        if (!dirPreExisted)
+            extractTo.removeRecursively();
+    };
 
     BackupFile configChecker(source);
     bool needsPassword = false;
@@ -663,14 +672,14 @@ int cmdLegacyExtract(int argc, char *argv[])
         filePassword = qEnvironmentVariable("TRAKTOR_PASSWORD");
     if (needsPassword && filePassword.isEmpty()) {
         fprintf(stderr, "Error: backup is encrypted - provide a password with -p\n");
-        extractTo.removeRecursively();
+        cleanupIfCreated();
         return 1;
     }
 
     BackupFile backupFile(source, filePassword);
     if (!backupFile.open(QIODevice::ReadOnly)) {
         fprintf(stderr, "Error: cannot open file: %s\n", source.toLocal8Bit().constData());
-        extractTo.removeRecursively();
+        cleanupIfCreated();
         return 1;
     }
     backupFile.setConfig(needsPassword, compressionType);
@@ -678,7 +687,7 @@ int cmdLegacyExtract(int argc, char *argv[])
     if (!backupFile.isValid()) {
         fprintf(stderr, "Error: backup file is corrupted (missing end-of-file marker)\n");
         backupFile.close();
-        extractTo.removeRecursively();
+        cleanupIfCreated();
         return 1;
     }
 
@@ -701,7 +710,7 @@ int cmdLegacyExtract(int argc, char *argv[])
 
     if (!ok) {
         fprintf(stderr, "Extraction failed.\n");
-        extractTo.removeRecursively();
+        cleanupIfCreated();
         return 1;
     }
 

--- a/src/clihandler.h
+++ b/src/clihandler.h
@@ -18,4 +18,20 @@ int cmdExtract(int argc, char *argv[]);
 int cmdCat(int argc, char *argv[]);
 int cmdVerify(int argc, char *argv[]);
 
+// Print the global --help text shown for `traktor` and `traktor --help`.
+void printGlobalHelp();
+
+// Dispatch a known CLI subcommand (list/info/extract/cat/verify/mcp/
+// install-cli/uninstall). Sets *handled = true and returns the
+// subcommand's exit code on a match. Sets *handled = false if argv[1]
+// is not a recognized subcommand. Each branch constructs its own
+// QCoreApplication; no GUI dependency.
+int dispatchCliSubcommand(int argc, char *argv[], bool *handled);
+
+// Legacy `--source <file> --destination <dir> [-p password]` extract
+// path. Constructs its own QCoreApplication. Used by the Linux CLI
+// fallback when GUI is unavailable but the user asked for an
+// extraction.
+int cmdLegacyExtract(int argc, char *argv[]);
+
 #endif // CLIHANDLER_H

--- a/src/gui_entry.cpp
+++ b/src/gui_entry.cpp
@@ -1,0 +1,227 @@
+// Linux-only GUI entry point loaded via dlopen() from src/main.cpp.
+//
+// Hosts the QApplication, MainWindow, AutoExtractor and the macOS-style
+// FileOpen-event startup window. The body below is the GUI/auto-extract
+// path lifted verbatim from the pre-split src/main.cpp; only the entry
+// signature changed (was int main, is now extern "C" int run_gui).
+//
+// On macOS / Windows the same logic runs inline inside main.cpp under
+// the #ifndef __linux__ branch — gui_entry.cpp is not compiled there.
+
+#include "appdelegate.h"
+#include "autoextractor.h"
+#include "backupfile.h"
+#include "dockprogress.h"
+#include "extractionworker.h"
+#include "mainwindow.h"
+#include <QApplication>
+#include <QCommandLineParser>
+#include <QDir>
+#include <QFileInfo>
+#include <QFileOpenEvent>
+#include <QLocalSocket>
+#include <QTimer>
+#include <cstdio>
+
+static void printProgress(float percent)
+{
+    int filled = static_cast<int>(percent / 5.0f);
+    fprintf(stdout, "\r[");
+    for (int i = 0; i < 20; i++)
+        fputc(i < filled ? '#' : ' ', stdout);
+    fprintf(stdout, "] %3d%%", static_cast<int>(percent));
+    fflush(stdout);
+}
+
+extern "C" int run_gui(int argc, char **argv)
+{
+    QApplication a(argc, argv);
+
+    // Register Traktor as the default handler for .wpress files (no-op on Linux).
+    claimFileType();
+
+    QCommandLineParser parser;
+    parser.setApplicationDescription("Qtraktor - All-in-One WP Migration and Backup extractor");
+    parser.addHelpOption();
+    parser.addVersionOption();
+
+    QCommandLineOption sourceOption(QStringList() << "s" << "source", "Backup file to open (.wpress)", "source");
+    parser.addOption(sourceOption);
+
+    QCommandLineOption destinationOption(QStringList() << "d" << "destination", "Directory to extract the backup into",
+                                         "destination");
+    parser.addOption(destinationOption);
+
+    QCommandLineOption passwordOption(QStringList() << "p" << "password", "Password for encrypted backup", "password");
+    parser.addOption(passwordOption);
+
+    parser.addPositionalArgument("file", "Backup file to open (.wpress)", "[file]");
+
+    parser.process(a);
+
+    QString source = parser.value(sourceOption);
+    const QStringList positional = parser.positionalArguments();
+    if (source.isEmpty() && !positional.isEmpty())
+        source = positional.first();
+
+    const QString destination = parser.value(destinationOption);
+    const QString password = parser.value(passwordOption);
+
+    // ── Legacy CLI extract mode ────────────────────────────────────────────
+    if (!source.isEmpty() && !destination.isEmpty()) {
+        QFileInfo fileInfo(source);
+        if (!fileInfo.isReadable()) {
+            fprintf(stderr, "Error: cannot read file: %s\n", source.toLocal8Bit().constData());
+            return 1;
+        }
+
+        QDir extractTo(destination + "/" + fileInfo.baseName());
+        if (!QDir().mkdir(extractTo.path())) {
+            fprintf(stderr, "Error: cannot create directory: %s\n", extractTo.path().toLocal8Bit().constData());
+            return 1;
+        }
+
+        BackupFile configChecker(source);
+        bool needsPassword = false;
+        CompressionType compressionType = COMPRESSION_NONE;
+
+        if (configChecker.open(QIODevice::ReadOnly)) {
+            if (configChecker.isValid()) {
+                needsPassword = configChecker.isEncryptedFile();
+                compressionType = configChecker.getCompressionType();
+            }
+            configChecker.close();
+        }
+
+        QString filePassword = password;
+        if (needsPassword && filePassword.isEmpty()) {
+            fprintf(stderr, "Error: backup is encrypted - provide a password with -p\n");
+            extractTo.removeRecursively();
+            return 1;
+        }
+
+        BackupFile backupFile(source, filePassword);
+        if (!backupFile.open(QIODevice::ReadOnly)) {
+            fprintf(stderr, "Error: cannot open file: %s\n", source.toLocal8Bit().constData());
+            extractTo.removeRecursively();
+            return 1;
+        }
+        backupFile.setConfig(needsPassword, compressionType);
+
+        if (!backupFile.isValid()) {
+            fprintf(stderr, "Error: backup file is corrupted (missing end-of-file marker)\n");
+            backupFile.close();
+            extractTo.removeRecursively();
+            return 1;
+        }
+
+        fprintf(stdout, "File : %s\n", fileInfo.fileName().toLocal8Bit().constData());
+        fprintf(stdout, "To   : %s\n", extractTo.path().toLocal8Bit().constData());
+        fflush(stdout);
+
+        QObject::connect(&backupFile, &BackupFile::progress, printProgress);
+
+        QObject::connect(&backupFile, &BackupFile::error, [](const QString &msg) {
+            fprintf(stderr, "\nError: %s\n", msg.toLocal8Bit().constData());
+            fflush(stderr);
+        });
+
+        const bool ok = backupFile.extract(extractTo);
+        backupFile.close();
+
+        fprintf(stdout, "\n");
+        fflush(stdout);
+
+        if (!ok) {
+            fprintf(stderr, "Extraction failed.\n");
+            extractTo.removeRecursively();
+            return 1;
+        }
+
+        fprintf(stdout, "Done. Extracted to: %s\n", extractTo.path().toLocal8Bit().constData());
+        fflush(stdout);
+        return 0;
+    }
+
+    // ── Auto-extract mode ──────────────────────────────────────────────────
+    // Positional args without --source/--destination flags = double-click / file association
+    const bool hasExplicitSource = parser.isSet(sourceOption);
+    if (!positional.isEmpty() && !hasExplicitSource) {
+        // Try single-instance: forward to existing instance if running
+        QLocalSocket socket;
+        socket.connectToServer("com.servmask.Traktor");
+        if (socket.waitForConnected(500)) {
+            for (const QString &file : positional) {
+                socket.write((file + "\n").toUtf8());
+            }
+            socket.waitForBytesWritten(1000);
+            socket.disconnectFromServer();
+            return 0;
+        }
+
+        AutoExtractor extractor(positional);
+        AppDelegate appDelegate(nullptr, &extractor);
+        a.installEventFilter(&appDelegate);
+
+        return QApplication::exec();
+    }
+
+    // ── GUI or macOS file-open mode ─────────────────────────────────────────
+    if (!source.isEmpty()) {
+        MainWindow w;
+        AppDelegate appDelegate(&w);
+        a.installEventFilter(&appDelegate);
+        w.openBackupFile(source);
+        if (!password.isEmpty())
+            w.setPassword(password);
+        w.show();
+        return QApplication::exec();
+    }
+
+    // No args at all: wait briefly for macOS FileOpen events
+    QStringList pendingFiles;
+    bool decided = false;
+    MainWindow *window = nullptr;
+    AutoExtractor *extractor = nullptr;
+
+    class StartupFilter : public QObject
+    {
+    public:
+        QStringList *files;
+        bool *decided;
+        explicit StartupFilter(QStringList *f, bool *d, QObject *p = nullptr) : QObject(p), files(f), decided(d) {}
+        bool eventFilter(QObject *, QEvent *event) override
+        {
+            if (event->type() == QEvent::FileOpen) {
+                QFileOpenEvent *e = static_cast<QFileOpenEvent *>(event);
+
+                if (!*decided) {
+                    files->append(e->file());
+                    return true;
+                }
+            }
+            return false;
+        }
+    };
+
+    StartupFilter startupFilter(&pendingFiles, &decided);
+    a.installEventFilter(&startupFilter);
+
+    QTimer::singleShot(300, [&]() {
+        decided = true;
+        a.removeEventFilter(&startupFilter);
+
+        if (!pendingFiles.isEmpty()) {
+            extractor = new AutoExtractor(pendingFiles);
+            AppDelegate *appDel = new AppDelegate(nullptr, extractor);
+            a.installEventFilter(appDel);
+        } else {
+            window = new MainWindow();
+            AppDelegate *appDel = new AppDelegate(window);
+            a.installEventFilter(appDel);
+            window->show();
+        }
+    });
+
+    return QApplication::exec();
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,14 +32,17 @@
 static void detachFromConsole()
 {
 #ifdef Q_OS_WIN
-    HWND console = GetConsoleWindow();
-    if (console) {
-        DWORD consolePid = 0;
-        GetWindowThreadProcessId(console, &consolePid);
-        if (consolePid == GetCurrentProcessId())
+    // GetWindowThreadProcessId(GetConsoleWindow(), ...) returns the PID of
+    // conhost.exe (the out-of-process console host), not our PID — so a
+    // self-ownership check is always false. The documented idiom is
+    // GetConsoleProcessList: a count of 1 means we are the sole attachee,
+    // i.e. Windows allocated this console for us at launch (Explorer flow).
+    // A count > 1 means we inherited the user's terminal — leave it alone.
+    if (GetConsoleProcessList(nullptr, 0) == 1) {
+        if (HWND console = GetConsoleWindow())
             ShowWindow(console, SW_HIDE);
+        FreeConsole();
     }
-    FreeConsole();
 #endif
 }
 
@@ -347,10 +350,19 @@ static int runGuiInline(int argc, char **argv)
         }
 
         QDir extractTo(destination + "/" + fileInfo.baseName());
+        // mkpath() returns true when the directory already exists, so on
+        // error paths we must only removeRecursively() the dir if WE created
+        // it — otherwise we'd silently wipe a user's pre-existing directory
+        // (e.g. a prior successful extraction at the same destination).
+        const bool dirPreExisted = QFileInfo::exists(extractTo.path());
         if (!QDir().mkpath(extractTo.path())) {
             fprintf(stderr, "Error: cannot create directory: %s\n", extractTo.path().toLocal8Bit().constData());
             return 1;
         }
+        auto cleanupIfCreated = [&] {
+            if (!dirPreExisted)
+                extractTo.removeRecursively();
+        };
 
         // Read config header to detect encryption / compression
         BackupFile configChecker(source);
@@ -370,14 +382,14 @@ static int runGuiInline(int argc, char **argv)
             filePassword = qEnvironmentVariable("TRAKTOR_PASSWORD");
         if (needsPassword && filePassword.isEmpty()) {
             fprintf(stderr, "Error: backup is encrypted – provide a password with -p\n");
-            extractTo.removeRecursively();
+            cleanupIfCreated();
             return 1;
         }
 
         BackupFile backupFile(source, filePassword);
         if (!backupFile.open(QIODevice::ReadOnly)) {
             fprintf(stderr, "Error: cannot open file: %s\n", source.toLocal8Bit().constData());
-            extractTo.removeRecursively();
+            cleanupIfCreated();
             return 1;
         }
         backupFile.setConfig(needsPassword, compressionType);
@@ -385,7 +397,7 @@ static int runGuiInline(int argc, char **argv)
         if (!backupFile.isValid()) {
             fprintf(stderr, "Error: backup file is corrupted (missing end-of-file marker)\n");
             backupFile.close();
-            extractTo.removeRecursively();
+            cleanupIfCreated();
             return 1;
         }
 
@@ -408,7 +420,7 @@ static int runGuiInline(int argc, char **argv)
 
         if (!ok) {
             fprintf(stderr, "Extraction failed.\n");
-            extractTo.removeRecursively();
+            cleanupIfCreated();
             return 1;
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,35 +1,72 @@
-#include "mainwindow.h"
-#include "appdelegate.h"
-#include "autoextractor.h"
-#include "backupfile.h"
+// Traktor entry point.
+//
+// All platforms: argv[1] subcommand dispatch routes list/info/extract/
+// cat/verify/mcp/install-cli/uninstall through QCoreApplication. --help
+// and --version are intercepted before any Q*Application is constructed
+// so the loader never has to resolve QtGui / libGL just to print help.
+//
+// Linux: this file links only Qt6::Core. The GUI lives in
+// libtraktor-gui.so which we dlopen() at runtime when the user wants
+// it (and the system can support it). On a minimal container (no
+// $DISPLAY, no libGL) the binary stays in CLI mode.
+//
+// macOS / Windows: the GUI runs inline below under #ifndef __linux__.
+// No dlopen, no plugin — the executable links Qt6::Widgets directly,
+// exactly as it always has.
+
 #include "clihandler.h"
-#include "dockprogress.h"
-#include "extractionworker.h"
-#include "installcli.h"
-#include "mcpserver.h"
-#include <QApplication>
-#include <QCommandLineParser>
-#include <QCoreApplication>
-#include <QFileInfo>
-#include <QDir>
-#include <QFileOpenEvent>
-#include <QLocalSocket>
-#include <QTimer>
+#include <QString>
 #include <cstdio>
+#include <cstring>
 
 #ifdef Q_OS_WIN
 #include <windows.h>
 #endif
 
-static void attachConsole()
+// Windows builds use the console subsystem so CLI subcommands (--help,
+// list, extract, ...) print reliably to any shell. The cost is that a
+// console window is allocated when launching from Explorer. Hide it (only
+// if we own the console — never the inherited terminal of cmd / PowerShell
+// / Windows Terminal) and detach before the GUI event loop starts so the
+// GUI looks clean. No-op on macOS/Linux.
+static void detachFromConsole()
 {
 #ifdef Q_OS_WIN
-    if (AttachConsole(ATTACH_PARENT_PROCESS)) {
-        freopen("CONOUT$", "w", stdout);
-        freopen("CONOUT$", "w", stderr);
+    HWND console = GetConsoleWindow();
+    if (console) {
+        DWORD consolePid = 0;
+        GetWindowThreadProcessId(console, &consolePid);
+        if (consolePid == GetCurrentProcessId())
+            ShowWindow(console, SW_HIDE);
     }
+    FreeConsole();
 #endif
 }
+
+#ifdef __linux__
+#include <dlfcn.h>
+#include <linux/limits.h>
+#include <unistd.h>
+#include <cstdlib>
+#include <initializer_list>
+#include <QDir>
+#include <QFileInfo>
+#endif
+
+#ifndef __linux__
+#include "appdelegate.h"
+#include "autoextractor.h"
+#include "backupfile.h"
+#include "dockprogress.h"
+#include "extractionworker.h"
+#include "mainwindow.h"
+#include <QApplication>
+#include <QCommandLineParser>
+#include <QDir>
+#include <QFileInfo>
+#include <QFileOpenEvent>
+#include <QLocalSocket>
+#include <QTimer>
 
 static void printProgress(float percent)
 {
@@ -41,56 +78,181 @@ static void printProgress(float percent)
     fflush(stdout);
 }
 
-static void printGlobalHelp()
+static int runGuiInline(int argc, char **argv);
+#endif // !__linux__
+
+#ifdef __linux__
+
+static bool hasFlag(int argc, char **argv, const char *name)
 {
-    fprintf(stdout, "Qtraktor - All-in-One WP Migration and Backup extractor\n"
-                    "\n"
-                    "Usage: traktor <command> [options] <archive>\n"
-                    "\n"
-                    "Commands:\n"
-                    "  list        List contents of a .wpress archive\n"
-                    "  info        Show archive metadata (format, encryption, file count)\n"
-                    "  extract     Extract all files from a .wpress archive\n"
-                    "  cat         Stream a single file from an archive to stdout\n"
-                    "  verify      Verify archive integrity (CRC32)\n"
-                    "  mcp         Start MCP server for AI agent integration\n"
-                    "  install-cli Install command-line tool to system PATH (macOS)\n"
-                    "  uninstall   Remove CLI, AI agent integrations, and settings\n"
-                    "\n"
-                    "Global options:\n"
-                    "  -p, --password <pw>   Password for encrypted archives\n"
-                    "                        (or set TRAKTOR_PASSWORD environment variable)\n"
-                    "  --json                Machine-readable JSON output\n"
-                    "  -q, --quiet           Suppress progress output\n"
-                    "  -h, --help            Show this help\n"
-                    "  -v, --version         Show version\n"
-                    "\n"
-                    "Legacy mode:\n"
-                    "  traktor --source <file> --destination <dir> [-p password]\n"
-                    "\n"
-                    "Exit codes:\n"
-                    "  0  Success\n"
-                    "  1  General error (I/O, permissions, usage)\n"
-                    "  2  Invalid or corrupted archive\n"
-                    "  3  Wrong or missing password\n"
-                    "  4  CRC32 verification failure\n"
-                    "\n"
-                    "Examples:\n"
-                    "  traktor list backup.wpress\n"
-                    "  traktor list --json backup.wpress | jq '.path'\n"
-                    "  traktor cat backup.wpress wp-config.php | grep DB_PASSWORD\n"
-                    "  traktor verify --json backup.wpress\n"
-                    "  traktor extract backup.wpress ./output/\n");
-    fflush(stdout);
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], name) == 0)
+            return true;
+    }
+    return false;
 }
+
+// Strip the named flags from argv in-place. Argument vector is shrunk,
+// argc updated. We never touch argv[0]. Used so QCommandLineParser
+// downstream (in run_gui or cmdLegacyExtract) doesn't reject --gui /
+// --cli / --no-gui as unknown options.
+static void stripFlags(int *argc, char **argv, std::initializer_list<const char *> flags)
+{
+    int w = 1;
+    for (int r = 1; r < *argc; ++r) {
+        bool drop = false;
+        for (const char *f : flags) {
+            if (std::strcmp(argv[r], f) == 0) {
+                drop = true;
+                break;
+            }
+        }
+        if (!drop) {
+            argv[w++] = argv[r];
+        }
+    }
+    for (int i = w; i < *argc; ++i) {
+        argv[i] = nullptr;
+    }
+    *argc = w;
+}
+
+// Resolve absolute path to libtraktor-gui.so. We compute it from
+// /proc/self/exe so LD_LIBRARY_PATH / cwd don't matter. Try the
+// installed layout (../lib) first, then the build-tree layout (next to
+// the executable).
+static QString resolveGuiPluginPath(QString *errorOut)
+{
+    char buf[PATH_MAX];
+    ssize_t n = ::readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+    if (n <= 0) {
+        if (errorOut)
+            *errorOut = QStringLiteral("cannot read /proc/self/exe");
+        return QString();
+    }
+    buf[n] = '\0';
+    QFileInfo exe(QString::fromLocal8Bit(buf));
+    QDir d = exe.absoluteDir();
+    const char *candidates[] = {"../lib/libtraktor-gui.so", "libtraktor-gui.so"};
+    for (const char *rel : candidates) {
+        QString p = QDir::cleanPath(d.absoluteFilePath(QString::fromLatin1(rel)));
+        if (QFileInfo::exists(p))
+            return p;
+    }
+    if (errorOut)
+        *errorOut = QStringLiteral("libtraktor-gui.so not found next to executable");
+    return QString();
+}
+
+static int runGuiPlugin(int argc, char **argv, bool loudOnFail)
+{
+    QString err;
+    QString path = resolveGuiPluginPath(&err);
+    if (path.isEmpty()) {
+        if (loudOnFail)
+            std::fprintf(stderr, "traktor: %s\n", qPrintable(err));
+        return 1;
+    }
+    void *h = ::dlopen(path.toLocal8Bit().constData(), RTLD_NOW);
+    if (!h) {
+        if (loudOnFail)
+            std::fprintf(stderr, "traktor: cannot load GUI plugin: %s\n", ::dlerror());
+        return 1;
+    }
+    using RunGuiFn = int (*)(int, char **);
+    auto fn = reinterpret_cast<RunGuiFn>(::dlsym(h, "run_gui"));
+    if (!fn) {
+        if (loudOnFail)
+            std::fprintf(stderr, "traktor: GUI plugin missing run_gui symbol: %s\n", ::dlerror());
+        ::dlclose(h);
+        return 1;
+    }
+    return fn(argc, argv);
+}
+
+// Probe whether GUI mode is viable. Returns true and leaves whyOut
+// empty on success; returns false and writes a short reason on
+// failure. We dlclose what we open here — runGuiPlugin re-opens for
+// the real run.
+static bool guiProbeOk(QString *whyOut)
+{
+    if (!std::getenv("DISPLAY") && !std::getenv("WAYLAND_DISPLAY")) {
+        if (whyOut)
+            *whyOut = QStringLiteral("no display server (DISPLAY/WAYLAND_DISPLAY unset)");
+        return false;
+    }
+    void *gl = ::dlopen("libGL.so.1", RTLD_LAZY);
+    if (!gl) {
+        if (whyOut)
+            *whyOut = QStringLiteral("libGL.so.1 not loadable");
+        return false;
+    }
+    QString perr;
+    QString path = resolveGuiPluginPath(&perr);
+    if (path.isEmpty()) {
+        ::dlclose(gl);
+        if (whyOut)
+            *whyOut = perr;
+        return false;
+    }
+    void *gui = ::dlopen(path.toLocal8Bit().constData(), RTLD_NOW);
+    if (!gui) {
+        if (whyOut)
+            *whyOut = QString::fromLatin1("GUI plugin probe failed: %1").arg(QString::fromLocal8Bit(::dlerror()));
+        ::dlclose(gl);
+        return false;
+    }
+    ::dlclose(gui);
+    ::dlclose(gl);
+    return true;
+}
+
+// CLI-mode fallback: if --source/--destination were passed, run the
+// legacy extract; otherwise print the global help. Exit codes match
+// the legacy behavior.
+static int runCliFallback(int argc, char **argv)
+{
+    bool hasSrc = false, hasDst = false;
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "-s") == 0 || std::strcmp(argv[i], "--source") == 0 ||
+            std::strncmp(argv[i], "--source=", 9) == 0)
+            hasSrc = true;
+        if (std::strcmp(argv[i], "-d") == 0 || std::strcmp(argv[i], "--destination") == 0 ||
+            std::strncmp(argv[i], "--destination=", 14) == 0)
+            hasDst = true;
+    }
+    if (hasSrc && hasDst)
+        return cmdLegacyExtract(argc, argv);
+    printGlobalHelp();
+    return 0;
+}
+
+#endif // __linux__
 
 int main(int argc, char *argv[])
 {
-    // ── Two-phase init ─────────────────────────────────────────────────────
-    // Detect subcommand or --help from raw argv BEFORE creating any Qt
-    // application object. CLI subcommands use QCoreApplication (no display
-    // server needed). QCoreApplication is a singleton — the CLI path never
-    // creates QApplication. No event loop (exec()) in CLI path.
+#ifdef __linux__
+    // Detect and strip Linux GUI/CLI flags BEFORE the all-platforms subcommand
+    // dispatch so:
+    //   (a) `traktor list --gui backup.wpress` doesn't choke cmdList's
+    //       QCommandLineParser with "Unknown option: gui",
+    //   (b) `traktor --gui --help` resolves to printGlobalHelp() instead of
+    //       Qt's auto-generated mini-help inside run_gui.
+    bool forceGui = hasFlag(argc, argv, "--gui");
+    bool forceCli = hasFlag(argc, argv, "--cli") || hasFlag(argc, argv, "--no-gui");
+
+    if (forceGui && forceCli) {
+        std::fprintf(stderr, "traktor: --gui and --cli are mutually exclusive\n");
+        return 1;
+    }
+
+    stripFlags(&argc, argv, {"--gui", "--cli", "--no-gui"});
+#endif
+
+    // ── Subcommand dispatch (all platforms) ────────────────────────────────
+    // Detect subcommand or --help/--version from raw argv BEFORE creating
+    // any Q*Application. CLI subcommands use QCoreApplication only — they
+    // never construct QApplication and never need a display server.
     if (argc >= 2) {
         const QString sub = QString::fromLocal8Bit(argv[1]);
 
@@ -100,42 +262,50 @@ int main(int argc, char *argv[])
             printGlobalHelp();
             return 0;
         }
+        if (sub == "--version" || sub == "-v") {
+#ifdef PROJECT_VERSION_STR
+            std::printf("Traktor %s\n", PROJECT_VERSION_STR);
+#else
+            std::printf("Traktor (unknown version)\n");
+#endif
+            return 0;
+        }
 
-        if (sub == "list") {
-            QCoreApplication app(argc, argv);
-            return cmdList(argc, argv);
-        }
-        if (sub == "info") {
-            QCoreApplication app(argc, argv);
-            return cmdInfo(argc, argv);
-        }
-        if (sub == "extract") {
-            QCoreApplication app(argc, argv);
-            return cmdExtract(argc, argv);
-        }
-        if (sub == "cat") {
-            QCoreApplication app(argc, argv);
-            return cmdCat(argc, argv);
-        }
-        if (sub == "verify") {
-            QCoreApplication app(argc, argv);
-            return cmdVerify(argc, argv);
-        }
-        if (sub == "mcp") {
-            QCoreApplication app(argc, argv);
-            return cmdMcp();
-        }
-        if (sub == "install-cli") {
-            QCoreApplication app(argc, argv);
-            return cmdInstallCli();
-        }
-        if (sub == "uninstall") {
-            QCoreApplication app(argc, argv);
-            return cmdUninstall();
-        }
+        bool handled = false;
+        int rc = dispatchCliSubcommand(argc, argv, &handled);
+        if (handled)
+            return rc;
     }
 
-    // ── GUI / auto-extract path (existing, unchanged) ──────────────────────
+#ifdef __linux__
+    // ── Linux: hybrid CLI/GUI dispatch ─────────────────────────────────────
+    if (forceCli)
+        return runCliFallback(argc, argv);
+
+    if (forceGui)
+        return runGuiPlugin(argc, argv, /*loudOnFail=*/true);
+
+    QString why;
+    if (!guiProbeOk(&why)) {
+        std::fprintf(stderr,
+                     "traktor: GUI unavailable (%s); running in CLI mode. "
+                     "Re-run with --gui to see the specific error.\n",
+                     qPrintable(why));
+        return runCliFallback(argc, argv);
+    }
+    return runGuiPlugin(argc, argv, /*loudOnFail=*/true);
+#else
+    return runGuiInline(argc, argv);
+#endif
+}
+
+#ifndef __linux__
+// ── macOS / Windows GUI path (unchanged from pre-split main.cpp) ──────────
+// QApplication, MainWindow, AutoExtractor, the macOS FileOpen startup
+// window, and the legacy --source/--destination CLI extraction (which on
+// macOS/Windows runs inside QApplication for parity with prior releases).
+static int runGuiInline(int argc, char **argv)
+{
     QApplication a(argc, argv);
 
     // Register Traktor as the default handler for .wpress files
@@ -170,8 +340,6 @@ int main(int argc, char *argv[])
 
     // ── CLI mode ────────────────────────────────────────────────────────────
     if (!source.isEmpty() && !destination.isEmpty()) {
-        attachConsole();
-
         QFileInfo fileInfo(source);
         if (!fileInfo.isReadable()) {
             fprintf(stderr, "Error: cannot read file: %s\n", source.toLocal8Bit().constData());
@@ -179,7 +347,7 @@ int main(int argc, char *argv[])
         }
 
         QDir extractTo(destination + "/" + fileInfo.baseName());
-        if (!QDir().mkdir(extractTo.path())) {
+        if (!QDir().mkpath(extractTo.path())) {
             fprintf(stderr, "Error: cannot create directory: %s\n", extractTo.path().toLocal8Bit().constData());
             return 1;
         }
@@ -198,6 +366,8 @@ int main(int argc, char *argv[])
         }
 
         QString filePassword = password;
+        if (filePassword.isEmpty())
+            filePassword = qEnvironmentVariable("TRAKTOR_PASSWORD");
         if (needsPassword && filePassword.isEmpty()) {
             fprintf(stderr, "Error: backup is encrypted – provide a password with -p\n");
             extractTo.removeRecursively();
@@ -246,6 +416,12 @@ int main(int argc, char *argv[])
         fflush(stdout);
         return 0;
     }
+
+    // Past the CLI-only paths — we're going to QApplication::exec() one way
+    // or another (auto-extract, GUI with --source, or bare GUI). On Windows,
+    // drop the console window allocated for the console-subsystem binary so
+    // the GUI launch doesn't leave an empty cmd window behind.
+    detachFromConsole();
 
     // ── Auto-extract mode ──────────────────────────────────────────────────
     // Positional args without --source/--destination flags = double-click / file association
@@ -340,3 +516,4 @@ int main(int argc, char *argv[])
 
     return QApplication::exec();
 }
+#endif // !__linux__


### PR DESCRIPTION
Splits the Linux build into a thin CLI executable (`Traktor`) plus two shared libraries (`libtraktor-core.so`,
  `libtraktor-gui.so` loaded via `dlopen`), so subcommands like `traktor list backup.wpress` work on minimal/headless
  containers without `libGL`. macOS/Windows builds remain a single binary; on Windows we additionally switch to the console
   subsystem so CLI output is visible from PowerShell/cmd, and detach the console (only when we own it — never the user's
  inherited terminal) before the GUI event loop starts.

  The change is wrapped in `if(CMAKE_SYSTEM_NAME STREQUAL "Linux")` and `#ifdef __linux__`, so non-Linux platforms keep
  their existing single-target build. Adds `--gui` / `--cli` / `--no-gui` flags, auto-detection via
  `$DISPLAY`/`$WAYLAND_DISPLAY` and `dlopen` probes for `libGL.so.1` and the GUI plugin. Adds a global `--help` /
  `--version` handler and refactors subcommand dispatch out of `main.cpp` into `clihandler.cpp` so both the Linux thin exe
  and the macOS/Windows inline-GUI path share the same machinery. The `cmdLegacyExtract` path now honors the
  `TRAKTOR_PASSWORD` env var and uses `mkpath()` for parity with the new `extract` subcommand.

  ## Related Issue

  <!-- TODO: link if applicable -->

  ## Checklist

  - [x] PR title follows conventional commit format (`feat:`, `fix:`, `docs:`, etc.)
  - [x] Code compiles without warnings on at least one platform
  - [x] Tests pass locally (`cmake -B build && cmake --build build && cd build && ctest --output-on-failure`)
  - [x] New code follows existing style (run `clang-format -i` on changed files)
  - [ ] Added tests for new functionality (if applicable) — covered manually; no new unit tests for dispatch helpers
  (`dispatchCliSubcommand`, `guiProbeOk`, `detachFromConsole`)

  ## Screenshots / Output

  **Linux (WSL Ubuntu 24.04, Qt 6.8.0) — split verified:**

  $ ldd build-linux/Traktor | grep -E 'libGL.|libQt6Gui|libQt6Widgets'
  (no output — clean, exe links only Qt6Core + libtraktor-core + libcrypto + libz)

  $ ldd build-linux/libtraktor-gui.so | grep -E 'libGL.|libQt6Gui|libQt6Widgets'
          libQt6Widgets.so.6 => /home/.../Qt/6.8.0/gcc_64/lib/libQt6Widgets.so.6
          libQt6Gui.so.6     => /home/.../Qt/6.8.0/gcc_64/lib/libQt6Gui.so.6
          libGL.so.1         => /lib/x86_64-linux-gnu/libGL.so.1

  $ env -u DISPLAY -u WAYLAND_DISPLAY ./Traktor --version
  Traktor 1.8.0

  $ env -u DISPLAY -u WAYLAND_DISPLAY ./Traktor 2>&1 | head -2
  traktor: GUI unavailable (no display server (DISPLAY/WAYLAND_DISPLAY unset)); running in CLI mode. Re-run with --gui to
  see the specific error.
  Qtraktor - All-in-One WP Migration and Backup extractor

  $ env -u DISPLAY -u WAYLAND_DISPLAY ./Traktor --gui --cli   # exit 1
  traktor: --gui and --cli are mutually exclusive

  $ env -u DISPLAY -u WAYLAND_DISPLAY ./Traktor list --gui /tmp/missing.wpress
  Error: cannot read file: /tmp/missing.wpress
  (no "Unknown option: gui" — flag is stripped before subcommand dispatch)

  $ QT_QPA_PLATFORM=offscreen ctest --output-on-failure
  1/1 Test #1: QtraktorTests .................... Passed   3.82 sec
  100% tests passed, 0 tests failed out of 1

  **Windows (MinGW 13.1, Qt 6.10.1) — CLI works directly from PowerShell:**

  PS> .\Traktor.exe -v
  Traktor 1.8.0

  PS> .\Traktor.exe -h | Select-Object -First 4
  Qtraktor - All-in-One WP Migration and Backup extractor

  Usage: traktor  [options]

  PS> ctest --test-dir build --output-on-failure
  1/1 Test #1: QtraktorTests .................... Passed    0.32 sec
  100% tests passed, 0 tests failed out of 1