### PR TITLE
ci(macos): apply allow-jit entitlement to signed app bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,16 @@ jobs:
     needs: build-macos
     runs-on: macos-latest
     steps:
+      # Sparse checkout up-front: scripts/macos-pkg/ is needed for both
+      # entitlements.plist (codesign step) and the pkgbuild scripts/resources
+      # (PKG step). Doing it once here removes the previous "rename before
+      # checkout" + redundant second checkout pattern.
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/macos-pkg
+          sparse-checkout-cone-mode: false
+
       - name: Download arm64 app (full bundle)
         uses: actions/download-artifact@v4
         with:
@@ -178,8 +188,12 @@ jobs:
             codesign --force --options runtime --timestamp --sign "$IDENTITY" "$lib"
           done
 
-          # Sign the app bundle last
-          codesign --force --options runtime --timestamp --sign "$IDENTITY" Universal-Traktor.app
+          # Sign the app bundle last, with entitlements applied to the OUTER
+          # bundle only (not to nested frameworks per Apple guidance).
+          # See scripts/macos-pkg/entitlements.plist for the rationale.
+          codesign --force --options runtime --timestamp \
+            --entitlements scripts/macos-pkg/entitlements.plist \
+            --sign "$IDENTITY" Universal-Traktor.app
 
           codesign --verify --deep --strict --verbose=2 Universal-Traktor.app
 
@@ -203,20 +217,11 @@ jobs:
 
           rm -f "$RUNNER_TEMP/Traktor.zip"
 
-      - name: Rename app before checkout
-        run: mv Universal-Traktor.app /tmp/Traktor.app
-
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            scripts/macos-pkg
-          sparse-checkout-cone-mode: false
-
       - name: Build PKG installer
         env:
           INSTALLER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER }}
         run: |
-          mv /tmp/Traktor.app Traktor.app
+          mv Universal-Traktor.app Traktor.app
 
           # Generate component plist and disable bundle relocation
           mkdir -p /tmp/pkg-root

--- a/scripts/macos-pkg/entitlements.plist
+++ b/scripts/macos-pkg/entitlements.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Defense-in-depth for hardened runtime + Qt:
+         Qt's QRegularExpression is backed by PCRE2, which uses JIT
+         compilation when available. Hardened runtime blocks JIT memory
+         allocation by default; without this entitlement,
+         pcre2_jit_compile_16 → pthread_jit_write_protect_np crashes the
+         process with SIGTRAP the first time a regex compiles (e.g. when
+         QFileDialog parses its filter string).
+
+         Today this entitlement is technically not exercised in our
+         production builds because install-qt-action ships Qt with PCRE2
+         JIT disabled — but it costs nothing to grant and protects
+         against any future Qt-source change in CI. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- New `scripts/macos-pkg/entitlements.plist` granting `com.apple.security.cs.allow-jit`
- `release.yml`: pass `--entitlements` on the OUTER app codesign call only (not on framework signs, per Apple guidance)
- Simplify `package-macos`: single up-front sparse-checkout, drop the redundant late checkout + "rename app before checkout" pattern that previously existed only to protect the .app from the second checkout

## Why
Defense-in-depth for hardened runtime + Qt. Qt's `QRegularExpression` is backed by PCRE2, which JIT-compiles patterns when JIT support is built into PCRE2. Hardened runtime blocks JIT memory allocation by default; without this entitlement, `pcre2_jit_compile_16` → `pthread_jit_write_protect_np` SIGTRAPs the first time a regex compiles (e.g. when `QFileDialog` parses its filter string).

Production today is unaffected — `install-qt-action`'s Qt has PCRE2 JIT disabled (verified: no `pcre2_jit_*` symbols in the bundled `QtCore.framework`) — but this entitlement costs nothing to grant and protects against any future Qt-source change in CI that might enable PCRE2 JIT.

## Test plan
- [x] Local `cmake --build`: no behavioural change (entitlements file + `release.yml` are CI-only)
- [x] `workflow_dispatch` end-to-end: build → sign with `--entitlements` → notarize → staple .app → notarize PKG → staple PKG. Apple notary accepts the new entitlement (run [25439090998](https://github.com/servmask/Qtraktor/actions/runs/25439090998))
- [ ] Post-merge: verify Open Backup still works on a user's Mac after the next release-please cut (no regression from the entitlement)