### PR TITLE
feat(macos): in-app auto-update via Sparkle 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
 
           # Smoke test the bundled AppImage. --version routes through the CLI
           # path so no display is needed. Use whatever filename linuxdeploy
-          # produced (e.g. Traktor-x86_64.AppImage) — no rename needed.
+          # produced (e.g. Traktor-x86_64.AppImage) - no rename needed.
           appimage=$(ls Traktor-*.AppImage | head -n1)
           ./"$appimage" --version
 
@@ -298,7 +298,7 @@ jobs:
           # Bundle the OpenSSL + zlib runtime DLLs from vcpkg. Names follow
           # upstream OUTPUT_NAME conventions, not the package name:
           #   libssl-3-x64.dll, libcrypto-3-x64.dll  (OpenSSL)
-          #   z.dll                                  (zlib — OUTPUT_NAME "z")
+          #   z.dll                                  (zlib - OUTPUT_NAME "z")
           # Glob the version suffixes so port revisions don't break the bundle.
           $vcpkgBin = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin"
           Write-Host "vcpkg bin contents:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,16 @@ jobs:
     needs: build-macos
     runs-on: macos-latest
     steps:
+      # Sparse checkout up-front: scripts/macos-pkg/ is needed for both
+      # entitlements.plist (codesign step) and the pkgbuild scripts/resources
+      # (PKG step). Doing it once here removes the previous "rename before
+      # checkout" + redundant second checkout pattern.
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            scripts/macos-pkg
+          sparse-checkout-cone-mode: false
+
       - name: Download arm64 app (full bundle)
         uses: actions/download-artifact@v4
         with:
@@ -178,8 +188,12 @@ jobs:
             codesign --force --options runtime --timestamp --sign "$IDENTITY" "$lib"
           done
 
-          # Sign the app bundle last
-          codesign --force --options runtime --timestamp --sign "$IDENTITY" Universal-Traktor.app
+          # Sign the app bundle last, with entitlements applied to the OUTER
+          # bundle only (not to nested frameworks per Apple guidance).
+          # See scripts/macos-pkg/entitlements.plist for the rationale.
+          codesign --force --options runtime --timestamp \
+            --entitlements scripts/macos-pkg/entitlements.plist \
+            --sign "$IDENTITY" Universal-Traktor.app
 
           codesign --verify --deep --strict --verbose=2 Universal-Traktor.app
 
@@ -203,20 +217,11 @@ jobs:
 
           rm -f "$RUNNER_TEMP/Traktor.zip"
 
-      - name: Rename app before checkout
-        run: mv Universal-Traktor.app /tmp/Traktor.app
-
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            scripts/macos-pkg
-          sparse-checkout-cone-mode: false
-
       - name: Build PKG installer
         env:
           INSTALLER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER }}
         run: |
-          mv /tmp/Traktor.app Traktor.app
+          mv Universal-Traktor.app Traktor.app
 
           # Generate component plist and disable bundle relocation
           mkdir -p /tmp/pkg-root

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,14 +88,16 @@ jobs:
     needs: build-macos
     runs-on: macos-latest
     steps:
-      # Sparse checkout up-front: scripts/macos-pkg/ is needed for both
-      # entitlements.plist (codesign step) and the pkgbuild scripts/resources
-      # (PKG step). Doing it once here removes the previous "rename before
-      # checkout" + redundant second checkout pattern.
+      # Sparse checkout up-front: scripts/macos-pkg/ has entitlements.plist
+      # (codesign step) and pkgbuild scripts/resources (PKG step);
+      # scripts/sparkle/ has the appcast XML template (Sparkle artifact step).
+      # Doing it once here removes the previous "rename before checkout"
+      # + redundant second checkout pattern.
       - uses: actions/checkout@v4
         with:
           sparse-checkout: |
             scripts/macos-pkg
+            scripts/sparkle
           sparse-checkout-cone-mode: false
 
       - name: Download arm64 app (full bundle)
@@ -231,6 +233,62 @@ jobs:
           xcrun stapler validate Universal-Traktor.app
 
           rm -f "$RUNNER_TEMP/Traktor.zip"
+
+      - name: Build Sparkle update artifact and signed appcast
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
+        run: |
+          # Pin the Sparkle version to match CMakeLists.txt's FetchContent.
+          # Both versions must be kept in sync — the framework bundled into
+          # the .app and the sign_update tool used to sign the update zip
+          # should come from the same Sparkle release.
+          SPARKLE_VERSION=2.9.1
+          curl -sL \
+            "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz" \
+            -o "$RUNNER_TEMP/sparkle.tar.xz"
+          mkdir -p "$RUNNER_TEMP/sparkle-tools"
+          tar -xJf "$RUNNER_TEMP/sparkle.tar.xz" -C "$RUNNER_TEMP/sparkle-tools"
+          SIGN_UPDATE="$RUNNER_TEMP/sparkle-tools/bin/sign_update"
+
+          # Zip the (already-stapled) .app for Sparkle delivery.
+          # Sparkle's recommended form: --sequesterRsrc preserves resource
+          # forks (different from the notarization zip which uses
+          # --keepParent only).
+          ditto -c -k --sequesterRsrc --keepParent Universal-Traktor.app Traktor.app.zip
+
+          # Write the EdDSA private key to a temp file. The GitHub Secret
+          # value is already the 44-char base64 string in Sparkle's
+          # deployable format — paste-as-is, no decode step.
+          KEY_FILE="$RUNNER_TEMP/sparkle_private.key"
+          printf '%s' "$SPARKLE_PRIVATE_KEY" > "$KEY_FILE"
+          SPARKLE_SIG_LINE=$("$SIGN_UPDATE" -f "$KEY_FILE" Traktor.app.zip)
+          rm -f "$KEY_FILE"
+
+          # Render appcast-macos.xml from the template.
+          # VERSION_TAG keeps the leading "v" (e.g. v1.10.0) for URLs;
+          # VERSION_NUM strips it (e.g. 1.10.0) so sparkle:version matches
+          # CFBundleVersion/CFBundleShortVersionString in Info.plist.
+          # Python's os.path.expandvars is used instead of envsubst because
+          # gettext is not reliably on PATH on macOS runners (Homebrew's
+          # gettext is keg-only); python3 always is.
+          export VERSION_TAG="${{ env.VERSION }}"
+          export VERSION_NUM="${VERSION_TAG#v}"
+          export PUB_DATE="$(date -u +'%a, %d %b %Y %H:%M:%S +0000')"
+          export DOWNLOAD_URL="https://github.com/servmask/Qtraktor/releases/download/${VERSION_TAG}/Traktor.app.zip"
+          export SPARKLE_SIG_LINE
+          python3 -c 'import os, sys; sys.stdout.write(os.path.expandvars(sys.stdin.read()))' \
+            < scripts/sparkle/appcast-macos.xml.tmpl > appcast-macos.xml
+
+          echo "--- appcast-macos.xml ---"
+          cat appcast-macos.xml
+
+      - name: Upload Sparkle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Traktor-Sparkle-${{ env.VERSION }}
+          path: |
+            Traktor.app.zip
+            appcast-macos.xml
 
       - name: Build PKG installer
         env:
@@ -485,6 +543,8 @@ jobs:
             Traktor-${{ env.VERSION }}.pkg/Traktor-${{ env.VERSION }}.pkg \
             Traktor-${{ env.VERSION }}.exe/Traktor-${{ env.VERSION }}.exe \
             Traktor-x86_64-${{ env.VERSION }}.AppImage/Traktor-x86_64-${{ env.VERSION }}.AppImage \
+            Traktor-Sparkle-${{ env.VERSION }}/Traktor.app.zip \
+            Traktor-Sparkle-${{ env.VERSION }}/appcast-macos.xml \
             --repo "${{ github.repository }}"
 
       - name: Update Homebrew Cask

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,11 +62,11 @@ jobs:
           rm -rf build/Traktor.app/Contents/PlugIns/networkinformation \
                  build/Traktor.app/Contents/PlugIns/tls
 
-      - name: Archive app (arm64 — full bundle with Qt frameworks)
+      - name: Archive app (arm64 - full bundle with Qt frameworks)
         if: matrix.arch == 'arm64'
         run: tar -cf Traktor-arm64.app.tar -C build Traktor.app
 
-      - name: Archive binary only (x86_64 — just the executable and OpenSSL)
+      - name: Archive binary only (x86_64 - just the executable and OpenSSL)
         if: matrix.arch == 'x86_64'
         run: |
           # Only archive files that need lipo merge (Traktor binary + OpenSSL)
@@ -219,7 +219,7 @@ jobs:
           ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
           ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
         run: |
-          # notarytool doesn't accept .app directly — wrap in a zip first
+          # notarytool doesn't accept .app directly - wrap in a zip first
           ditto -c -k --keepParent Universal-Traktor.app "$RUNNER_TEMP/Traktor.zip"
 
           xcrun notarytool submit "$RUNNER_TEMP/Traktor.zip" \
@@ -239,7 +239,7 @@ jobs:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
         run: |
           # Pin the Sparkle version to match CMakeLists.txt's FetchContent.
-          # Both versions must be kept in sync — the framework bundled into
+          # Both versions must be kept in sync - the framework bundled into
           # the .app and the sign_update tool used to sign the update zip
           # should come from the same Sparkle release.
           SPARKLE_VERSION=2.9.1
@@ -258,7 +258,7 @@ jobs:
 
           # Write the EdDSA private key to a temp file. The GitHub Secret
           # value is already the 44-char base64 string in Sparkle's
-          # deployable format — paste-as-is, no decode step.
+          # deployable format - paste-as-is, no decode step.
           KEY_FILE="$RUNNER_TEMP/sparkle_private.key"
           printf '%s' "$SPARKLE_PRIVATE_KEY" > "$KEY_FILE"
           SPARKLE_SIG_LINE=$("$SIGN_UPDATE" -f "$KEY_FILE" Traktor.app.zip)
@@ -393,7 +393,7 @@ jobs:
           # Bundle the OpenSSL + zlib runtime DLLs from vcpkg. Names follow
           # upstream OUTPUT_NAME conventions, not the package name:
           #   libssl-3-x64.dll, libcrypto-3-x64.dll  (OpenSSL)
-          #   z.dll                                  (zlib — OUTPUT_NAME "z")
+          #   z.dll                                  (zlib - OUTPUT_NAME "z")
           # Glob the version suffixes so port revisions don't break the bundle.
           $vcpkgBin = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin"
           Write-Host "vcpkg bin contents:"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,21 @@ jobs:
         env:
           IDENTITY: ${{ secrets.APPLE_DEVELOPER_ID_APP }}
         run: |
+          # Sparkle.framework contains nested helper bundles (Updater.app,
+          # Autoupdate executable, XPCServices/{Downloader,Installer}.xpc)
+          # that ship pre-signed ad-hoc in the Sparkle release tarball.
+          # Apple notarization requires every nested binary to be signed
+          # by our Developer ID, so we re-sign them inside-out BEFORE the
+          # generic framework loop below.
+          SPARKLE_V="Universal-Traktor.app/Contents/Frameworks/Sparkle.framework/Versions/B"
+          if [ -d "$SPARKLE_V" ]; then
+            for xpc in "$SPARKLE_V"/XPCServices/*.xpc; do
+              codesign --force --options runtime --timestamp --sign "$IDENTITY" "$xpc"
+            done
+            codesign --force --options runtime --timestamp --sign "$IDENTITY" "$SPARKLE_V/Updater.app"
+            codesign --force --options runtime --timestamp --sign "$IDENTITY" "$SPARKLE_V/Autoupdate"
+          fi
+
           # Inside-out: frameworks → dylibs → plugins → main app
           find Universal-Traktor.app/Contents/Frameworks -name "*.framework" -type d | while IFS= read -r fw; do
             codesign --force --options runtime --timestamp --sign "$IDENTITY" "$fw"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 
 ### Features
 
-* **Hybrid CLI/GUI mode** — split GUI behind a runtime probe ([#40](https://github.com/servmask/Qtraktor/issues/40))
-  * Linux: thin executable links only `Qt6::Core` + `libdl`; the Widgets GUI lives in `libtraktor-gui.so` and is `dlopen`'d at runtime when `$DISPLAY`/`$WAYLAND_DISPLAY`, `libGL.so.1`, and the plugin all probe successfully — minimal/headless containers stay in CLI mode without loader errors
+* **Hybrid CLI/GUI mode** - split GUI behind a runtime probe ([#40](https://github.com/servmask/Qtraktor/issues/40))
+  * Linux: thin executable links only `Qt6::Core` + `libdl`; the Widgets GUI lives in `libtraktor-gui.so` and is `dlopen`'d at runtime when `$DISPLAY`/`$WAYLAND_DISPLAY`, `libGL.so.1`, and the plugin all probe successfully - minimal/headless containers stay in CLI mode without loader errors
   * Windows: switched to the console subsystem so CLI subcommands pipe stdout cleanly from PowerShell/cmd; the console is detached only when Traktor owns it (never the user's inherited terminal) before the GUI event loop starts
   * Adds `--gui` / `--cli` / `--no-gui` flags, a global `--help` / `--version` handler, and refactors subcommand dispatch out of `main.cpp` into `clihandler.cpp` so the Linux thin exe and the macOS/Windows inline-GUI path share the same machinery
   * `cmdLegacyExtract` now honors the `TRAKTOR_PASSWORD` env var and uses `mkpath()` for parity with the new `extract` subcommand
@@ -36,13 +36,13 @@
 
 ### Features
 
-* **Qt 6.8 LTS + CMake + C++17** — Full framework modernization ([#26](https://github.com/servmask/Qtraktor/issues/26)) ([fa019f3](https://github.com/servmask/Qtraktor/commit/fa019f3))
+* **Qt 6.8 LTS + CMake + C++17** - Full framework modernization ([#26](https://github.com/servmask/Qtraktor/issues/26)) ([fa019f3](https://github.com/servmask/Qtraktor/commit/fa019f3))
   * Upgraded from Qt 5.15 (end-of-life) to Qt 6.8 LTS (supported until 2028)
   * Migrated build system from qmake to CMake
   * Upgraded C++ standard from C++11 to C++17
   * macOS: minimum version raised to 11.0 (Big Sur), required by Qt 6
   * Windows: upgraded to MSVC 2022 and Qt 6.8
-  * Leaner macOS app bundle — stripped unused Qt 6 frameworks (QML, SVG)
+  * Leaner macOS app bundle - stripped unused Qt 6 frameworks (QML, SVG)
 
 
 ### Bug Fixes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ cmake -B build -DCMAKE_BUILD_TYPE=Release \
   -DOPENSSL_ROOT_DIR="$(brew --prefix openssl)"
 cmake --build build -j$(sysctl -n hw.ncpu)
 
-# Linux (Qt 6.8 required — install via package manager or aqtinstall)
+# Linux (Qt 6.8 required - install via package manager or aqtinstall)
 sudo apt install cmake qt6-base-dev libgl1-mesa-dev libssl-dev zlib1g-dev pkg-config
 cmake -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j$(nproc)
@@ -34,7 +34,7 @@ cd build && ctest --output-on-failure  # Linux/macOS
 cd build && ctest --output-on-failure  # Windows
 ```
 
-97 tests across 6 test classes: BackupFile (13), CryptoUtils streaming (7), ExtractionWorker (9), QSettings (6), Fuzz (15), CLI (39 — covers CrcDevice, path normalization, header iteration, single-file extraction, archive info, MCP protocol, and AgentConfigManager). Tests use QTest framework. Test entry point is `tests/tst_main.cpp` which runs all classes sequentially.
+97 tests across 6 test classes: BackupFile (13), CryptoUtils streaming (7), ExtractionWorker (9), QSettings (6), Fuzz (15), CLI (39 - covers CrcDevice, path normalization, header iteration, single-file extraction, archive info, MCP protocol, and AgentConfigManager). Tests use QTest framework. Test entry point is `tests/tst_main.cpp` which runs all classes sequentially.
 
 On headless Linux (CI), set `QT_QPA_PLATFORM=offscreen` because tests use QApplication.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,10 @@ if(APPLE)
     set_target_properties(Traktor PROPERTIES
         MACOSX_BUNDLE TRUE
         MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_BINARY_DIR}/Info.plist
+        # @executable_path/../Frameworks is where Sparkle.framework (and Qt
+        # frameworks once macdeployqt runs) live inside the .app bundle.
+        INSTALL_RPATH "@executable_path/../Frameworks"
+        BUILD_WITH_INSTALL_RPATH TRUE
     )
 
     target_link_libraries(Traktor PRIVATE
@@ -222,6 +226,39 @@ if(APPLE)
     target_sources(Traktor PRIVATE ${ICON_FILES})
     set_source_files_properties(${ICON_FILES} PROPERTIES
         MACOSX_PACKAGE_LOCATION Resources
+    )
+
+    # ── Sparkle auto-update framework ──────────────────────────────────────
+    # Vendored via FetchContent — downloaded at configure time, not committed.
+    # macdeployqt does NOT bundle non-Qt frameworks (per Qt's deployment
+    # docs), so we copy Sparkle.framework into the .app via the POST_BUILD
+    # step below. The existing inside-out codesign loop in release.yml
+    # picks it up automatically once it's in Contents/Frameworks/.
+    include(FetchContent)
+    FetchContent_Declare(Sparkle
+        URL https://github.com/sparkle-project/Sparkle/releases/download/2.9.1/Sparkle-2.9.1.tar.xz
+        URL_HASH SHA256=c0dde519fd2a43ddfc6a1eb76aec284d7d888fe281414f9177de3164d98ba4c7
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(Sparkle)
+
+    target_link_libraries(Traktor PRIVATE
+        "-F${sparkle_SOURCE_DIR}"
+        "-framework Sparkle"
+    )
+
+    # Copy Sparkle.framework into the .app bundle's Contents/Frameworks/
+    # after the binary links. We use `ditto` (not `cmake -E copy_directory`)
+    # because Sparkle.framework relies on symlinks at its top level
+    # (Sparkle -> Versions/Current/Sparkle, Headers -> Versions/Current/Headers,
+    # etc.). `cmake -E copy_directory` dereferences those symlinks, producing
+    # two copies of every binary and breaking codesign with
+    # "bundle format is ambiguous (could be app or framework)".
+    add_custom_command(TARGET Traktor POST_BUILD
+        COMMAND ditto
+                "${sparkle_SOURCE_DIR}/Sparkle.framework"
+                "$<TARGET_BUNDLE_DIR:Traktor>/Contents/Frameworks/Sparkle.framework"
+        VERBATIM
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
 
 # macOS deployment target (must be before find_package for proper SDK targeting)
 if(APPLE)
@@ -46,6 +47,7 @@ set(APP_SOURCES
     src/agentconfig.cpp
     src/setupdialog.cpp
     src/passworddialog.cpp
+    src/aboutdialog.cpp
     src/appdelegate.cpp
     src/dropoverlay.cpp
     src/extractionworker.cpp
@@ -63,6 +65,7 @@ set(APP_HEADERS
     src/agentconfig.h
     src/setupdialog.h
     src/passworddialog.h
+    src/aboutdialog.h
     src/appdelegate.h
     src/dropoverlay.h
     src/extractionworker.h
@@ -72,6 +75,7 @@ set(APP_HEADERS
 )
 
 set(APP_FORMS src/mainwindow.ui)
+set(APP_RESOURCES resources.qrc)
 
 # Platform-specific sources
 if(APPLE)
@@ -136,6 +140,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         src/mainwindow.cpp
         src/setupdialog.cpp
         src/passworddialog.cpp
+        src/aboutdialog.cpp
         src/autoextractor.cpp
         src/progresswindow.cpp
         src/dropoverlay.cpp
@@ -147,6 +152,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         src/mainwindow.h
         src/setupdialog.h
         src/passworddialog.h
+        src/aboutdialog.h
         src/autoextractor.h
         src/progresswindow.h
         src/dropoverlay.h
@@ -154,7 +160,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         src/dockprogress.h
     )
     qt_add_library(traktor-gui SHARED
-        ${GUI_SOURCES} ${GUI_HEADERS} src/mainwindow.ui
+        ${GUI_SOURCES} ${GUI_HEADERS} src/mainwindow.ui ${APP_RESOURCES}
     )
     target_link_libraries(traktor-gui PRIVATE
         traktor-core
@@ -183,7 +189,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     install(TARGETS Traktor RUNTIME DESTINATION bin)
     install(TARGETS traktor-core traktor-gui LIBRARY DESTINATION lib)
 else()
-    qt_add_executable(Traktor ${APP_SOURCES} ${APP_HEADERS} ${APP_FORMS})
+    qt_add_executable(Traktor ${APP_SOURCES} ${APP_HEADERS} ${APP_FORMS} ${APP_RESOURCES})
 
     target_include_directories(Traktor PRIVATE src)
 
@@ -199,10 +205,18 @@ else()
     )
 endif()
 
-# Project version is consumed by main.cpp's --version handler on every platform.
+# Project version is consumed by main.cpp's --version handler on every platform,
+# and by AboutDialog on macOS/Windows (where aboutdialog.cpp is in the Traktor
+# target). On Linux, AboutDialog lives in libtraktor-gui.so, so the same macro
+# must be defined for that target too.
 target_compile_definitions(Traktor PRIVATE
     PROJECT_VERSION_STR="${PROJECT_VERSION}"
 )
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_compile_definitions(traktor-gui PRIVATE
+        PROJECT_VERSION_STR="${PROJECT_VERSION}"
+    )
+endif()
 
 # macOS bundle configuration
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,13 @@ set(APP_FORMS src/mainwindow.ui)
 # Platform-specific sources
 if(APPLE)
     enable_language(OBJCXX)
-    list(APPEND APP_SOURCES src/dockprogress.mm)
+    list(APPEND APP_SOURCES src/dockprogress.mm src/updatemanager.mm)
+    list(APPEND APP_HEADERS src/updatemanager.h)
+    # ARC for updatemanager.mm: cleaner ownership of SPUStandardUpdaterController
+    # and the KVO observer (raw Obj-C pointers in the C++ pimpl are __strong by
+    # default under ARC, so destruction releases them automatically).
+    set_source_files_properties(src/updatemanager.mm PROPERTIES
+        COMPILE_FLAGS "-fobjc-arc")
 else()
     list(APPEND APP_SOURCES src/dockprogress_stub.cpp)
 endif()
@@ -242,6 +248,10 @@ if(APPLE)
     )
     FetchContent_MakeAvailable(Sparkle)
 
+    # -F adds Sparkle's parent dir to the framework search path. Needed at
+    # both compile time (so #import <Sparkle/Sparkle.h> resolves) and link
+    # time (so -framework Sparkle finds it).
+    target_compile_options(Traktor PRIVATE "-F${sparkle_SOURCE_DIR}")
     target_link_libraries(Traktor PRIVATE
         "-F${sparkle_SOURCE_DIR}"
         "-framework Sparkle"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     # ── Hybrid CLI/GUI build (Linux only) ──────────────────────────────────
-    # The executable links Qt6::Core only — no libGL, no QtGui, no
+    # The executable links Qt6::Core only - no libGL, no QtGui, no
     # QtWidgets in DT_NEEDED. The GUI lives in libtraktor-gui.so which
     # main.cpp dlopen()s at runtime when probes for $DISPLAY, libGL.so.1
     # and the plugin itself succeed. On a minimal container the binary
@@ -249,7 +249,7 @@ if(APPLE)
     )
 
     # ── Sparkle auto-update framework ──────────────────────────────────────
-    # Vendored via FetchContent — downloaded at configure time, not committed.
+    # Vendored via FetchContent - downloaded at configure time, not committed.
     # macdeployqt does NOT bundle non-Qt frameworks (per Qt's deployment
     # docs), so we copy Sparkle.framework into the .app via the POST_BUILD
     # step below. The existing inside-out codesign loop in release.yml

--- a/Info.plist.in
+++ b/Info.plist.in
@@ -10,6 +10,10 @@
     <string>APPL</string>
     <key>CFBundleSignature</key>
     <string>@QMAKE_PKGINFO_TYPEINFO@</string>
+    <key>CFBundleShortVersionString</key>
+    <string>@PROJECT_VERSION@</string>
+    <key>CFBundleVersion</key>
+    <string>@PROJECT_VERSION@</string>
     <key>CFBundleIconFile</key>
     <string>traktor.icns</string>
     <key>LSMinimumSystemVersion</key>
@@ -17,6 +21,12 @@
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>SUFeedURL</key>
+    <string>https://github.com/servmask/Qtraktor/releases/latest/download/appcast-macos.xml</string>
+    <key>SUPublicEDKey</key>
+    <string>Ui6Y0zPGi/B4GEln/6fcf8wKXdHwy7BfWf2fNwE5n6c=</string>
+    <key>SUEnableAutomaticChecks</key>
     <true/>
     <key>CFBundleDocumentTypes</key>
     <array>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Cross-platform desktop application for extracting WordPress `.wpress` backup fil
 
 **Installer (recommended):**
 
-Download [Traktor.pkg](https://github.com/servmask/Qtraktor/releases/latest) — installs the app to `/Applications` and adds the `traktor` CLI to your terminal.
+Download [Traktor.pkg](https://github.com/servmask/Qtraktor/releases/latest) - installs the app to `/Applications` and adds the `traktor` CLI to your terminal.
 
 **Homebrew:**
 
@@ -45,7 +45,7 @@ Download [Traktor.exe](https://github.com/servmask/Qtraktor/releases/latest) ins
 
 ### Linux
 
-Download [Traktor.AppImage](https://github.com/servmask/Qtraktor/releases/latest) — make executable and run.
+Download [Traktor.AppImage](https://github.com/servmask/Qtraktor/releases/latest) - make executable and run.
 
 ## Command Line
 
@@ -87,7 +87,7 @@ traktor mcp register
 traktor mcp status
 ```
 
-After registration, your AI agent can use Traktor as a tool — ask it "what's in this .wpress backup?" and it just works.
+After registration, your AI agent can use Traktor as a tool - ask it "what's in this .wpress backup?" and it just works.
 
 ## Building from Source
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -154,6 +154,7 @@
       text-transform: uppercase;
       letter-spacing: 0.08em;
       margin-bottom: 14px;
+      scroll-margin-top: 24px;
     }
 
     .features {
@@ -247,8 +248,8 @@
       <div class="feat"><div class="fl">Cross-Platform</div><div class="fd">macOS, Windows, Linux</div></div>
     </div>
 
-    <div class="sec-label">Changelog</div>
-    <div class="clog" id="changelog">
+    <div class="sec-label" id="changelog">Changelog</div>
+    <div class="clog" id="changelog-content">
       <div class="loading">Loading...</div>
     </div>
 
@@ -328,7 +329,7 @@
         const vtLinks = parseVTLinks(rel.body);
         document.getElementById('downloads').innerHTML = assets.map((a,i) => card(a, i===0, vtLinks)).join('');
 
-        const cl = document.getElementById('changelog');
+        const cl = document.getElementById('changelog-content');
         if (rel.body) {
           let b = rel.body
             .replace(/^## .+$/gm, '')
@@ -345,6 +346,13 @@
           cl.innerHTML = `<h3>What's new in ${rel.tag_name}</h3>${b}`;
         } else {
           cl.innerHTML = '<p style="color:var(--text-dim)">No changelog yet.</p>';
+        }
+
+        // Re-scroll if the user landed on #changelog: the initial browser
+        // scroll happened against the empty placeholder, so the resolved
+        // position is wrong once the real content (much taller) renders.
+        if (location.hash === '#changelog') {
+          document.getElementById('changelog').scrollIntoView();
         }
       } catch(e) {
         document.getElementById('downloads').innerHTML =

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>icons/traktor.png</file>
+    </qresource>
+</RCC>

--- a/scripts/macos-pkg/entitlements.plist
+++ b/scripts/macos-pkg/entitlements.plist
@@ -12,7 +12,7 @@
 
          Today this entitlement is technically not exercised in our
          production builds because install-qt-action ships Qt with PCRE2
-         JIT disabled — but it costs nothing to grant and protects
+         JIT disabled - but it costs nothing to grant and protects
          against any future Qt-source change in CI. -->
     <key>com.apple.security.cs.allow-jit</key>
     <true/>

--- a/scripts/macos-pkg/entitlements.plist
+++ b/scripts/macos-pkg/entitlements.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Defense-in-depth for hardened runtime + Qt:
+         Qt's QRegularExpression is backed by PCRE2, which uses JIT
+         compilation when available. Hardened runtime blocks JIT memory
+         allocation by default; without this entitlement,
+         pcre2_jit_compile_16 → pthread_jit_write_protect_np crashes the
+         process with SIGTRAP the first time a regex compiles (e.g. when
+         QFileDialog parses its filter string).
+
+         Today this entitlement is technically not exercised in our
+         production builds because install-qt-action ships Qt with PCRE2
+         JIT disabled — but it costs nothing to grant and protects
+         against any future Qt-source change in CI. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/macos-pkg/resources/conclusion.html
+++ b/scripts/macos-pkg/resources/conclusion.html
@@ -37,7 +37,7 @@
     </div>
 
     <div class="section">
-        <strong>AI agent integration</strong> — register with your coding agents:
+        <strong>AI agent integration</strong> - register with your coding agents:
         <br><br>
         <code>traktor mcp register</code>
     </div>

--- a/scripts/sparkle/appcast-macos.xml.tmpl
+++ b/scripts/sparkle/appcast-macos.xml.tmpl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+    Sparkle 2 appcast for Traktor (macOS).
+
+    Rendered by .github/workflows/release.yml at release time. Variables
+    substituted via python3 os.path.expandvars (placeholders shown with
+    angle brackets here so the rendering pass doesn't substitute the
+    documentation itself):
+      <VERSION_TAG>       — release tag, e.g. "v1.10.0"
+      <VERSION_NUM>       — bare version, e.g. "1.10.0" (matches CFBundleVersion)
+      <PUB_DATE>          — RFC-822 publication date
+      <DOWNLOAD_URL>      — full URL to the signed Traktor.app.zip on the release
+      <SPARKLE_SIG_LINE>  — output of sign_update -f <key> Traktor.app.zip,
+                             e.g. sparkle:edSignature="..." length="..."
+
+    The published appcast lives at:
+      https://github.com/servmask/Qtraktor/releases/latest/download/appcast-macos.xml
+    (the latest/download/ redirect resolves to the current release, so the
+    URL embedded in the app via SUFeedURL stays static across versions.)
+-->
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+    <channel>
+        <title>Traktor</title>
+        <link>https://github.com/servmask/Qtraktor</link>
+        <description>Auto-update feed for Traktor (macOS)</description>
+        <language>en</language>
+        <item>
+            <title>Version ${VERSION_NUM}</title>
+            <pubDate>${PUB_DATE}</pubDate>
+            <sparkle:version>${VERSION_NUM}</sparkle:version>
+            <sparkle:shortVersionString>${VERSION_NUM}</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>11.0</sparkle:minimumSystemVersion>
+            <sparkle:releaseNotesLink>https://github.com/servmask/Qtraktor/releases/tag/${VERSION_TAG}</sparkle:releaseNotesLink>
+            <enclosure url="${DOWNLOAD_URL}" type="application/octet-stream" ${SPARKLE_SIG_LINE} />
+        </item>
+    </channel>
+</rss>

--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -4,9 +4,43 @@
 #include <QDate>
 #include <QFont>
 #include <QFrame>
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QPalette>
 #include <QVBoxLayout>
+
+namespace
+{
+
+// Mid-luma blend of WindowText against Window — gives a muted hairline /
+// secondary-text colour that adapts to light/dark mode while staying ≥4.5:1
+// against Window (WCAG 2.1 AA for body text).
+QColor mutedTextColor(const QPalette &pal, qreal mix = 0.55)
+{
+    QColor fg = pal.color(QPalette::WindowText);
+    QColor bg = pal.color(QPalette::Window);
+    return QColor::fromRgbF(fg.redF() * mix + bg.redF() * (1 - mix), fg.greenF() * mix + bg.greenF() * (1 - mix),
+                            fg.blueF() * mix + bg.blueF() * (1 - mix));
+}
+
+// Hairline divider: 1 px filled QWidget tinted with a low-mix blend of
+// WindowText into Window. Subtler than QFrame::HLine (which paints with the
+// full WindowText colour and reads as a stark line on dark backgrounds).
+// 3:1 against Window is the WCAG 2.1 AA threshold for non-text UI components,
+// but a hairline divider is decorative — readability is not at stake — so
+// we go lower (mix=0.18, ≈2:1) to match the design.
+QWidget *makeHairline(QWidget *parent)
+{
+    auto *line = new QWidget(parent);
+    line->setFixedHeight(1);
+    line->setAutoFillBackground(true);
+    QPalette pal = line->palette();
+    pal.setColor(QPalette::Window, mutedTextColor(pal, 0.04));
+    line->setPalette(pal);
+    return line;
+}
+
+} // namespace
 
 AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
 {
@@ -18,11 +52,11 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
     outer->setSpacing(0);
 
     auto *body = new QVBoxLayout;
-    body->setContentsMargins(40, 32, 40, 24);
+    body->setContentsMargins(60, 32, 60, 0);
     body->setSpacing(0);
 
     // App icon — pulled from the QApplication window icon set in MainWindow.
-    QPixmap iconPixmap = QApplication::windowIcon().pixmap(96, 96);
+    QPixmap iconPixmap = QApplication::windowIcon().pixmap(65, 65);
     if (!iconPixmap.isNull()) {
         auto *iconLabel = new QLabel(this);
         iconLabel->setPixmap(iconPixmap);
@@ -31,14 +65,29 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
         body->addSpacing(20);
     }
 
-    // Combined name + version on one line ("Traktor 1.9.1").
-    auto *titleLabel = new QLabel(QStringLiteral("Traktor %1").arg(QStringLiteral(PROJECT_VERSION_STR)), this);
+    // App name — 22 px Medium (weight 500). Pixel size keeps it consistent
+    // across platforms regardless of UI font DPI.
+    auto *titleLabel = new QLabel(QStringLiteral("Traktor"), this);
     QFont titleFont = titleLabel->font();
-    titleFont.setPointSize(titleFont.pointSize() + 8);
-    titleFont.setBold(true);
+    titleFont.setPixelSize(22);
+    titleFont.setWeight(QFont::Medium);
+    titleFont.setLetterSpacing(QFont::PercentageSpacing, 105.0);
     titleLabel->setFont(titleFont);
     titleLabel->setAlignment(Qt::AlignCenter);
     body->addWidget(titleLabel);
+
+    body->addSpacing(3);
+
+    // Version line — secondary text in the same muted colour as the footer.
+    auto *versionLabel = new QLabel(tr("Version %1").arg(QStringLiteral(PROJECT_VERSION_STR)), this);
+    QFont versionFont = versionLabel->font();
+    versionFont.setPixelSize(11);
+    versionLabel->setFont(versionFont);
+    versionLabel->setAlignment(Qt::AlignCenter);
+    QPalette versionPal = versionLabel->palette();
+    versionPal.setColor(QPalette::WindowText, mutedTextColor(versionPal, 0.55));
+    versionLabel->setPalette(versionPal);
+    body->addWidget(versionLabel);
 
     body->addSpacing(20);
 
@@ -50,33 +99,42 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
     taglineLabel->setAlignment(Qt::AlignCenter);
     body->addWidget(taglineLabel);
 
-    body->addSpacing(20);
+    outer->addLayout(body);
 
-    // Three external links separated by middle-dot bullets. Single rich-text
-    // QLabel so the row centres as a unit and wraps cleanly on narrow widths.
+    // Three external links separated by middle-dot bullets. Lives in its
+    // own row with smaller horizontal margins than the body content above,
+    // so all three labels + bullets fit on a single line at the dialog's
+    // 380 px width. Inline text-decoration:none drops the underline
+    // (mockup style); links remain identifiable by their accent colour
+    // (3:1+ against body text via palette Link role) plus the pointing-hand
+    // cursor on hover, satisfying WCAG 2.1 SC 1.4.1 (Use of Color).
     auto *linksLabel = new QLabel(this);
-    linksLabel->setText(QStringLiteral("<a href=\"https://traktor.wp-migration.com/#changelog\">%1</a>"
-                                       " &nbsp;·&nbsp; "
-                                       "<a href=\"https://github.com/servmask/Qtraktor/issues/new/choose\">%2</a>"
-                                       " &nbsp;·&nbsp; "
-                                       "<a href=\"https://github.com/servmask/Qtraktor\">%3</a>")
-                            .arg(tr("What's new"), tr("Report a bug"), tr("View on GitHub")));
+    const QString bullet = QStringLiteral(" &nbsp;&nbsp;<span style=\"color:%1\">·</span>&nbsp;&nbsp; ")
+                               .arg(mutedTextColor(linksLabel->palette(), 0.16).name());
+    linksLabel->setText(
+        QStringLiteral("<a href=\"https://traktor.wp-migration.com/#changelog\" style=\"text-decoration:none;\">%1</a>"
+                       "%4"
+                       "<a href=\"https://github.com/servmask/Qtraktor/issues/new/choose\" "
+                       "style=\"text-decoration:none;\">%2</a>"
+                       "%4"
+                       "<a href=\"https://github.com/servmask/Qtraktor\" style=\"text-decoration:none;\">%3</a>")
+            .arg(tr("What's new"), tr("Report a bug"), tr("View on GitHub"), bullet));
     linksLabel->setTextFormat(Qt::RichText);
     linksLabel->setOpenExternalLinks(true);
     linksLabel->setAlignment(Qt::AlignCenter);
-    linksLabel->setWordWrap(true);
-    body->addWidget(linksLabel);
+    linksLabel->setWordWrap(true); // graceful fallback if a translation overflows
+    auto *linksRow = new QHBoxLayout;
+    linksRow->setContentsMargins(16, 20, 16, 24);
+    linksRow->addWidget(linksLabel);
+    outer->addLayout(linksRow);
 
-    outer->addLayout(body);
+    // Hairline divider above the footer.
+    outer->addWidget(makeHairline(this));
 
-    // Divider above the footer.
-    auto *divider = new QFrame(this);
-    divider->setFrameShape(QFrame::HLine);
-    divider->setFrameShadow(QFrame::Plain);
-    outer->addWidget(divider);
-
-    // Footer — copyright + license, smaller and muted (palette-driven so it
-    // adapts to light/dark mode).
+    // Footer — copyright + license, smaller and muted. Uses a 0.55 mix of
+    // WindowText into Window which lands at ≥4.5:1 contrast in macOS dark
+    // mode (WCAG 2.1 AA for body text). PlaceholderText would be too light
+    // on some platforms; the explicit blend is portable.
     auto *footer = new QLabel(
         tr("© %1 ServMask Inc. · Licensed under GPLv3").arg(QString::number(QDate::currentDate().year())), this);
     QFont footerFont = footer->font();
@@ -84,10 +142,15 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
     footer->setFont(footerFont);
     footer->setAlignment(Qt::AlignCenter);
     QPalette footerPal = footer->palette();
-    footerPal.setColor(QPalette::WindowText, footerPal.color(QPalette::Disabled, QPalette::WindowText));
+    footerPal.setColor(QPalette::WindowText, mutedTextColor(footerPal, 0.55));
     footer->setPalette(footerPal);
-    footer->setContentsMargins(0, 12, 0, 12);
+    footer->setContentsMargins(0, 14, 0, 14);
     outer->addWidget(footer);
 
-    setFixedSize(sizeHint());
+    // Lock width first so word-wrap / sizeHint() compute the right height,
+    // then freeze the dialog at that exact size. 520 px fits all three
+    // links + bullets on a single row in the system font at default size.
+    setFixedWidth(380);
+    adjustSize();
+    setFixedSize(size());
 }

--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -1,0 +1,130 @@
+#include "aboutdialog.h"
+
+#include <QApplication>
+#include <QDate>
+#include <QDialogButtonBox>
+#include <QFont>
+#include <QLabel>
+#include <QVBoxLayout>
+
+#ifdef Q_OS_MAC
+#include "updatemanager.h"
+#include <QCheckBox>
+#include <QPushButton>
+#include <QSignalBlocker>
+#endif
+
+AboutDialog::AboutDialog(UpdateManager *updateManager, QWidget *parent)
+    : QDialog(parent), m_updateManager(updateManager)
+{
+    setWindowTitle(tr("About Traktor"));
+    setModal(true);
+
+    auto *layout = new QVBoxLayout(this);
+    layout->setContentsMargins(32, 28, 32, 20);
+    layout->setSpacing(6);
+
+    // App icon — only rendered if QApplication has a window icon set.
+    QPixmap iconPixmap = QApplication::windowIcon().pixmap(96, 96);
+    if (!iconPixmap.isNull()) {
+        auto *iconLabel = new QLabel(this);
+        iconLabel->setPixmap(iconPixmap);
+        iconLabel->setAlignment(Qt::AlignCenter);
+        layout->addWidget(iconLabel);
+        layout->addSpacing(8);
+    }
+
+    // App name
+    auto *nameLabel = new QLabel(QStringLiteral("Traktor"), this);
+    QFont nameFont = nameLabel->font();
+    nameFont.setPointSize(nameFont.pointSize() + 6);
+    nameFont.setBold(true);
+    nameLabel->setFont(nameFont);
+    nameLabel->setAlignment(Qt::AlignCenter);
+    layout->addWidget(nameLabel);
+
+    // Version
+    auto *versionLabel = new QLabel(tr("Version %1").arg(QStringLiteral(PROJECT_VERSION_STR)), this);
+    versionLabel->setAlignment(Qt::AlignCenter);
+    layout->addWidget(versionLabel);
+
+    layout->addSpacing(10);
+
+    // Tagline — All-in-One WP Migration & Backup is ServMask's own plugin
+    // (the one that creates .wpress files); link points to its WP.org page.
+    auto *taglineLabel = new QLabel(tr("Extracts .wpress backup files from<br>"
+                                       "<a href=\"https://wordpress.org/plugins/all-in-one-wp-migration/\">"
+                                       "All-in-One WP Migration &amp; Backup</a>."),
+                                    this);
+    taglineLabel->setAlignment(Qt::AlignCenter);
+    taglineLabel->setOpenExternalLinks(true);
+    taglineLabel->setTextFormat(Qt::RichText);
+    layout->addWidget(taglineLabel);
+
+    layout->addSpacing(10);
+
+    // Homepage + license links
+    auto *linksLabel =
+        new QLabel(tr("<a href=\"https://github.com/servmask/Qtraktor\">github.com/servmask/Qtraktor</a><br>"
+                      "Licensed under <a href=\"https://www.gnu.org/licenses/gpl-3.0.html\">GPLv3</a>"),
+                   this);
+    linksLabel->setAlignment(Qt::AlignCenter);
+    linksLabel->setOpenExternalLinks(true);
+    layout->addWidget(linksLabel);
+
+    layout->addSpacing(10);
+
+    // Copyright — matches the canonical format used in ServMask's PHP
+    // codebases ("Copyright (C) 2014-YYYY ServMask Inc."). Year auto-updates
+    // via QDate::currentDate() so we never have to remember to bump it.
+    auto *copyrightLabel =
+        new QLabel(tr("Copyright © 2014-%1 ServMask Inc.").arg(QString::number(QDate::currentDate().year())), this);
+    QFont copyrightFont = copyrightLabel->font();
+    copyrightFont.setPointSize(copyrightFont.pointSize() - 1);
+    copyrightLabel->setFont(copyrightFont);
+    copyrightLabel->setAlignment(Qt::AlignCenter);
+    layout->addWidget(copyrightLabel);
+
+#ifdef Q_OS_MAC
+    // Update controls — only meaningful on macOS where Sparkle is integrated.
+    // Windows/Linux users see the dialog without these widgets at all.
+    if (m_updateManager) {
+        layout->addSpacing(16);
+
+        // Check for Updates button — bound to UpdateManager::canCheckForUpdates
+        auto *checkButton = new QPushButton(tr("Check for Updates..."), this);
+        layout->addWidget(checkButton, 0, Qt::AlignCenter);
+        checkButton->setEnabled(m_updateManager->canCheckForUpdates());
+        connect(checkButton, &QPushButton::clicked, m_updateManager, &UpdateManager::checkForUpdates);
+        connect(m_updateManager, &UpdateManager::canCheckForUpdatesChanged, this,
+                [this, checkButton] { checkButton->setEnabled(m_updateManager->canCheckForUpdates()); });
+
+        layout->addSpacing(10);
+
+        // Auto-check checkbox — two-way bound to
+        // UpdateManager::automaticallyChecksForUpdates (NSUserDefaults-backed,
+        // persists across launches via Sparkle).
+        auto *autoCheckBox = new QCheckBox(tr("Automatically check for updates"), this);
+        layout->addWidget(autoCheckBox, 0, Qt::AlignCenter);
+        autoCheckBox->setChecked(m_updateManager->automaticallyChecksForUpdates());
+        connect(autoCheckBox, &QCheckBox::toggled, m_updateManager, &UpdateManager::setAutomaticallyChecksForUpdates);
+        // Reflect external changes (e.g. another window of the app, or
+        // Sparkle's own UI flipping the value) without re-emitting toggled().
+        connect(m_updateManager, &UpdateManager::automaticallyChecksForUpdatesChanged, this, [this, autoCheckBox] {
+            QSignalBlocker blocker(autoCheckBox);
+            autoCheckBox->setChecked(m_updateManager->automaticallyChecksForUpdates());
+        });
+    }
+#else
+    Q_UNUSED(m_updateManager);
+#endif
+
+    layout->addSpacing(12);
+
+    // Close button
+    auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close, this);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+    layout->addWidget(buttonBox);
+
+    setFixedSize(sizeHint());
+}

--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -2,129 +2,92 @@
 
 #include <QApplication>
 #include <QDate>
-#include <QDialogButtonBox>
 #include <QFont>
+#include <QFrame>
 #include <QLabel>
+#include <QPalette>
 #include <QVBoxLayout>
 
-#ifdef Q_OS_MAC
-#include "updatemanager.h"
-#include <QCheckBox>
-#include <QPushButton>
-#include <QSignalBlocker>
-#endif
-
-AboutDialog::AboutDialog(UpdateManager *updateManager, QWidget *parent)
-    : QDialog(parent), m_updateManager(updateManager)
+AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
 {
     setWindowTitle(tr("About Traktor"));
     setModal(true);
 
-    auto *layout = new QVBoxLayout(this);
-    layout->setContentsMargins(32, 28, 32, 20);
-    layout->setSpacing(6);
+    auto *outer = new QVBoxLayout(this);
+    outer->setContentsMargins(0, 0, 0, 0);
+    outer->setSpacing(0);
 
-    // App icon — only rendered if QApplication has a window icon set.
+    auto *body = new QVBoxLayout;
+    body->setContentsMargins(40, 32, 40, 24);
+    body->setSpacing(0);
+
+    // App icon — pulled from the QApplication window icon set in MainWindow.
     QPixmap iconPixmap = QApplication::windowIcon().pixmap(96, 96);
     if (!iconPixmap.isNull()) {
         auto *iconLabel = new QLabel(this);
         iconLabel->setPixmap(iconPixmap);
         iconLabel->setAlignment(Qt::AlignCenter);
-        layout->addWidget(iconLabel);
-        layout->addSpacing(8);
+        body->addWidget(iconLabel);
+        body->addSpacing(20);
     }
 
-    // App name
-    auto *nameLabel = new QLabel(QStringLiteral("Traktor"), this);
-    QFont nameFont = nameLabel->font();
-    nameFont.setPointSize(nameFont.pointSize() + 6);
-    nameFont.setBold(true);
-    nameLabel->setFont(nameFont);
-    nameLabel->setAlignment(Qt::AlignCenter);
-    layout->addWidget(nameLabel);
+    // Combined name + version on one line ("Traktor 1.9.1").
+    auto *titleLabel = new QLabel(QStringLiteral("Traktor %1").arg(QStringLiteral(PROJECT_VERSION_STR)), this);
+    QFont titleFont = titleLabel->font();
+    titleFont.setPointSize(titleFont.pointSize() + 8);
+    titleFont.setBold(true);
+    titleLabel->setFont(titleFont);
+    titleLabel->setAlignment(Qt::AlignCenter);
+    body->addWidget(titleLabel);
 
-    // Version
-    auto *versionLabel = new QLabel(tr("Version %1").arg(QStringLiteral(PROJECT_VERSION_STR)), this);
-    versionLabel->setAlignment(Qt::AlignCenter);
-    layout->addWidget(versionLabel);
-
-    layout->addSpacing(10);
+    body->addSpacing(20);
 
     // Tagline — All-in-One WP Migration & Backup is ServMask's own plugin
-    // (the one that creates .wpress files); link points to its WP.org page.
-    auto *taglineLabel = new QLabel(tr("Extracts .wpress backup files from<br>"
-                                       "<a href=\"https://wordpress.org/plugins/all-in-one-wp-migration/\">"
-                                       "All-in-One WP Migration &amp; Backup</a>."),
+    // (the one that creates .wpress files).
+    auto *taglineLabel = new QLabel(tr("Extracts .wpress backup files from\n"
+                                       "All-in-One WP Migration & Backup."),
                                     this);
     taglineLabel->setAlignment(Qt::AlignCenter);
-    taglineLabel->setOpenExternalLinks(true);
-    taglineLabel->setTextFormat(Qt::RichText);
-    layout->addWidget(taglineLabel);
+    body->addWidget(taglineLabel);
 
-    layout->addSpacing(10);
+    body->addSpacing(20);
 
-    // Homepage + license links
-    auto *linksLabel =
-        new QLabel(tr("<a href=\"https://github.com/servmask/Qtraktor\">github.com/servmask/Qtraktor</a><br>"
-                      "Licensed under <a href=\"https://www.gnu.org/licenses/gpl-3.0.html\">GPLv3</a>"),
-                   this);
-    linksLabel->setAlignment(Qt::AlignCenter);
+    // Three external links separated by middle-dot bullets. Single rich-text
+    // QLabel so the row centres as a unit and wraps cleanly on narrow widths.
+    auto *linksLabel = new QLabel(this);
+    linksLabel->setText(QStringLiteral("<a href=\"https://traktor.wp-migration.com/#changelog\">%1</a>"
+                                       " &nbsp;·&nbsp; "
+                                       "<a href=\"https://github.com/servmask/Qtraktor/issues/new/choose\">%2</a>"
+                                       " &nbsp;·&nbsp; "
+                                       "<a href=\"https://github.com/servmask/Qtraktor\">%3</a>")
+                            .arg(tr("What's new"), tr("Report a bug"), tr("View on GitHub")));
+    linksLabel->setTextFormat(Qt::RichText);
     linksLabel->setOpenExternalLinks(true);
-    layout->addWidget(linksLabel);
+    linksLabel->setAlignment(Qt::AlignCenter);
+    linksLabel->setWordWrap(true);
+    body->addWidget(linksLabel);
 
-    layout->addSpacing(10);
+    outer->addLayout(body);
 
-    // Copyright — matches the canonical format used in ServMask's PHP
-    // codebases ("Copyright (C) 2014-YYYY ServMask Inc."). Year auto-updates
-    // via QDate::currentDate() so we never have to remember to bump it.
-    auto *copyrightLabel =
-        new QLabel(tr("Copyright © 2014-%1 ServMask Inc.").arg(QString::number(QDate::currentDate().year())), this);
-    QFont copyrightFont = copyrightLabel->font();
-    copyrightFont.setPointSize(copyrightFont.pointSize() - 1);
-    copyrightLabel->setFont(copyrightFont);
-    copyrightLabel->setAlignment(Qt::AlignCenter);
-    layout->addWidget(copyrightLabel);
+    // Divider above the footer.
+    auto *divider = new QFrame(this);
+    divider->setFrameShape(QFrame::HLine);
+    divider->setFrameShadow(QFrame::Plain);
+    outer->addWidget(divider);
 
-#ifdef Q_OS_MAC
-    // Update controls — only meaningful on macOS where Sparkle is integrated.
-    // Windows/Linux users see the dialog without these widgets at all.
-    if (m_updateManager) {
-        layout->addSpacing(16);
-
-        // Check for Updates button — bound to UpdateManager::canCheckForUpdates
-        auto *checkButton = new QPushButton(tr("Check for Updates..."), this);
-        layout->addWidget(checkButton, 0, Qt::AlignCenter);
-        checkButton->setEnabled(m_updateManager->canCheckForUpdates());
-        connect(checkButton, &QPushButton::clicked, m_updateManager, &UpdateManager::checkForUpdates);
-        connect(m_updateManager, &UpdateManager::canCheckForUpdatesChanged, this,
-                [this, checkButton] { checkButton->setEnabled(m_updateManager->canCheckForUpdates()); });
-
-        layout->addSpacing(10);
-
-        // Auto-check checkbox — two-way bound to
-        // UpdateManager::automaticallyChecksForUpdates (NSUserDefaults-backed,
-        // persists across launches via Sparkle).
-        auto *autoCheckBox = new QCheckBox(tr("Automatically check for updates"), this);
-        layout->addWidget(autoCheckBox, 0, Qt::AlignCenter);
-        autoCheckBox->setChecked(m_updateManager->automaticallyChecksForUpdates());
-        connect(autoCheckBox, &QCheckBox::toggled, m_updateManager, &UpdateManager::setAutomaticallyChecksForUpdates);
-        // Reflect external changes (e.g. another window of the app, or
-        // Sparkle's own UI flipping the value) without re-emitting toggled().
-        connect(m_updateManager, &UpdateManager::automaticallyChecksForUpdatesChanged, this, [this, autoCheckBox] {
-            QSignalBlocker blocker(autoCheckBox);
-            autoCheckBox->setChecked(m_updateManager->automaticallyChecksForUpdates());
-        });
-    }
-#else
-    Q_UNUSED(m_updateManager);
-#endif
-
-    layout->addSpacing(12);
-
-    // Close button
-    auto *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close, this);
-    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
-    layout->addWidget(buttonBox);
+    // Footer — copyright + license, smaller and muted (palette-driven so it
+    // adapts to light/dark mode).
+    auto *footer = new QLabel(
+        tr("© %1 ServMask Inc. · Licensed under GPLv3").arg(QString::number(QDate::currentDate().year())), this);
+    QFont footerFont = footer->font();
+    footerFont.setPointSize(footerFont.pointSize() - 1);
+    footer->setFont(footerFont);
+    footer->setAlignment(Qt::AlignCenter);
+    QPalette footerPal = footer->palette();
+    footerPal.setColor(QPalette::WindowText, footerPal.color(QPalette::Disabled, QPalette::WindowText));
+    footer->setPalette(footerPal);
+    footer->setContentsMargins(0, 12, 0, 12);
+    outer->addWidget(footer);
 
     setFixedSize(sizeHint());
 }

--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -12,7 +12,7 @@
 namespace
 {
 
-// Mid-luma blend of WindowText against Window — gives a muted hairline /
+// Mid-luma blend of WindowText against Window - gives a muted hairline /
 // secondary-text colour that adapts to light/dark mode while staying ≥4.5:1
 // against Window (WCAG 2.1 AA for body text).
 QColor mutedTextColor(const QPalette &pal, qreal mix = 0.55)
@@ -27,7 +27,7 @@ QColor mutedTextColor(const QPalette &pal, qreal mix = 0.55)
 // WindowText into Window. Subtler than QFrame::HLine (which paints with the
 // full WindowText colour and reads as a stark line on dark backgrounds).
 // 3:1 against Window is the WCAG 2.1 AA threshold for non-text UI components,
-// but a hairline divider is decorative — readability is not at stake — so
+// but a hairline divider is decorative - readability is not at stake - so
 // we go lower (mix=0.18, ≈2:1) to match the design.
 QWidget *makeHairline(QWidget *parent)
 {
@@ -55,7 +55,7 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
     body->setContentsMargins(60, 32, 60, 0);
     body->setSpacing(0);
 
-    // App icon — pulled from the QApplication window icon set in MainWindow.
+    // App icon - pulled from the QApplication window icon set in MainWindow.
     QPixmap iconPixmap = QApplication::windowIcon().pixmap(65, 65);
     if (!iconPixmap.isNull()) {
         auto *iconLabel = new QLabel(this);
@@ -65,7 +65,7 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
         body->addSpacing(20);
     }
 
-    // App name — 22 px Medium (weight 500). Pixel size keeps it consistent
+    // App name - 22 px Medium (weight 500). Pixel size keeps it consistent
     // across platforms regardless of UI font DPI.
     auto *titleLabel = new QLabel(QStringLiteral("Traktor"), this);
     QFont titleFont = titleLabel->font();
@@ -78,7 +78,7 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
 
     body->addSpacing(3);
 
-    // Version line — secondary text in the same muted colour as the footer.
+    // Version line - secondary text in the same muted colour as the footer.
     auto *versionLabel = new QLabel(tr("Version %1").arg(QStringLiteral(PROJECT_VERSION_STR)), this);
     QFont versionFont = versionLabel->font();
     versionFont.setPixelSize(11);
@@ -91,7 +91,7 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
 
     body->addSpacing(20);
 
-    // Tagline — All-in-One WP Migration & Backup is ServMask's own plugin
+    // Tagline - All-in-One WP Migration & Backup is ServMask's own plugin
     // (the one that creates .wpress files).
     auto *taglineLabel = new QLabel(tr("Extracts .wpress backup files from\n"
                                        "All-in-One WP Migration & Backup."),
@@ -131,7 +131,7 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
     // Hairline divider above the footer.
     outer->addWidget(makeHairline(this));
 
-    // Footer — copyright + license, smaller and muted. Uses a 0.55 mix of
+    // Footer - copyright + license, smaller and muted. Uses a 0.55 mix of
     // WindowText into Window which lands at ≥4.5:1 contrast in macOS dark
     // mode (WCAG 2.1 AA for body text). PlaceholderText would be too light
     // on some platforms; the explicit blend is portable.

--- a/src/aboutdialog.h
+++ b/src/aboutdialog.h
@@ -1,0 +1,27 @@
+#ifndef ABOUTDIALOG_H
+#define ABOUTDIALOG_H
+
+#include <QDialog>
+
+class UpdateManager;
+
+// Modal "About Traktor" dialog. Triggered from the macOS app menu's About
+// item (QAction with AboutRole). Hosts the app icon, name, version, license
+// link, and the Sparkle update controls (Check for Updates button +
+// Automatically check for updates checkbox).
+
+class AboutDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    // updateManager may be nullptr — in that case the update controls are
+    // disabled. Useful if we ever wire this dialog up on a platform without
+    // Sparkle integration yet (Windows pending WinSparkle).
+    explicit AboutDialog(UpdateManager *updateManager, QWidget *parent = nullptr);
+
+private:
+    UpdateManager *m_updateManager; // non-owning
+};
+
+#endif // ABOUTDIALOG_H

--- a/src/aboutdialog.h
+++ b/src/aboutdialog.h
@@ -3,25 +3,20 @@
 
 #include <QDialog>
 
-class UpdateManager;
-
 // Modal "About Traktor" dialog. Triggered from the macOS app menu's About
-// item (QAction with AboutRole). Hosts the app icon, name, version, license
-// link, and the Sparkle update controls (Check for Updates button +
-// Automatically check for updates checkbox).
+// item (QAction with AboutRole). Shows the app icon, name + version, tagline,
+// external links (changelog, issues, repo), and copyright/license footer.
+//
+// Update controls live in the menu (see MainWindow's "Check for Updates…"
+// action), not in this dialog — Sparkle's progress UI cannot raise above an
+// application-modal Qt panel.
 
 class AboutDialog : public QDialog
 {
     Q_OBJECT
 
 public:
-    // updateManager may be nullptr — in that case the update controls are
-    // disabled. Useful if we ever wire this dialog up on a platform without
-    // Sparkle integration yet (Windows pending WinSparkle).
-    explicit AboutDialog(UpdateManager *updateManager, QWidget *parent = nullptr);
-
-private:
-    UpdateManager *m_updateManager; // non-owning
+    explicit AboutDialog(QWidget *parent = nullptr);
 };
 
 #endif // ABOUTDIALOG_H

--- a/src/aboutdialog.h
+++ b/src/aboutdialog.h
@@ -8,7 +8,7 @@
 // external links (changelog, issues, repo), and copyright/license footer.
 //
 // Update controls live in the menu (see MainWindow's "Check for Updates…"
-// action), not in this dialog — Sparkle's progress UI cannot raise above an
+// action), not in this dialog - Sparkle's progress UI cannot raise above an
 // application-modal Qt panel.
 
 class AboutDialog : public QDialog

--- a/src/agentconfig.cpp
+++ b/src/agentconfig.cpp
@@ -134,7 +134,7 @@ bool AgentConfigManager::registerAgent(AgentType type, QString *errorMsg)
             file.close();
 
             if (parseErr.error != QJsonParseError::NoError) {
-                // Invalid JSON — backup and start fresh
+                // Invalid JSON - backup and start fresh
                 const QString backupPath = path + ".bak";
                 QFile::remove(backupPath);
                 QFile::copy(path, backupPath);
@@ -164,7 +164,7 @@ bool AgentConfigManager::registerAgent(AgentType type, QString *errorMsg)
         if (existing["command"].toString() == command) {
             return true; // Already registered correctly
         }
-        // Stale path — update it
+        // Stale path - update it
     }
 
     mcpServers["traktor"] = traktorConfig;

--- a/src/backupfile.cpp
+++ b/src/backupfile.cpp
@@ -209,7 +209,7 @@ bool BackupFile::extractSingleFile(const QString &targetPath, QIODevice *dest)
         const QString entryPath = normalizePath(info.filePath, info.fileName);
 
         if (entryPath == normalizedTarget) {
-            // Found the target file — stream it to dest
+            // Found the target file - stream it to dest
             const bool isCompressed = !CryptoUtils::isConfigFile(info.fileName) && compressionType != COMPRESSION_NONE;
 
             QString processError;

--- a/src/backupfile.h
+++ b/src/backupfile.h
@@ -15,7 +15,7 @@
 
 // QIODevice sink that computes CRC32 on write and discards data.
 // Used by verify to check CRC without disk writes or memory bloat.
-// Pure sink — no downstream device, no buffering.
+// Pure sink - no downstream device, no buffering.
 class CrcDevice : public QIODevice
 {
 public:

--- a/src/clihandler.cpp
+++ b/src/clihandler.cpp
@@ -427,11 +427,11 @@ int cmdVerify(int /*argc*/, char * /*argv*/[])
                 }
                 fflush(stdout);
 
-                // Don't seek past content — streaming already consumed it
+                // Don't seek past content - streaming already consumed it
                 return true;
             }
 
-            // No CRC for this entry — iterateHeaders will skip content automatically
+            // No CRC for this entry - iterateHeaders will skip content automatically
 
             if (jsonMode) {
                 QJsonObject obj;
@@ -642,7 +642,7 @@ int cmdLegacyExtract(int argc, char *argv[])
 
     QDir extractTo(destination + "/" + fileInfo.baseName());
     // mkpath() returns true when the directory already exists, so on error
-    // paths we must only removeRecursively() the dir if WE created it —
+    // paths we must only removeRecursively() the dir if WE created it -
     // otherwise we'd silently wipe a user's pre-existing directory (e.g. a
     // prior successful extraction at the same destination).
     const bool dirPreExisted = QFileInfo::exists(extractTo.path());

--- a/src/gui_entry.cpp
+++ b/src/gui_entry.cpp
@@ -6,7 +6,7 @@
 // signature changed (was int main, is now extern "C" int run_gui).
 //
 // On macOS / Windows the same logic runs inline inside main.cpp under
-// the #ifndef __linux__ branch — gui_entry.cpp is not compiled there.
+// the #ifndef __linux__ branch - gui_entry.cpp is not compiled there.
 
 #include "appdelegate.h"
 #include "autoextractor.h"

--- a/src/installcli.cpp
+++ b/src/installcli.cpp
@@ -36,9 +36,9 @@ InstallResult installCli()
                     result.message += "\n" + msg;
                 return result;
             }
-            // Symlink points elsewhere — will overwrite
+            // Symlink points elsewhere - will overwrite
         } else {
-            // Regular file — refuse
+            // Regular file - refuse
             result.success = false;
             result.message = QString("A file already exists at %1 that is not a symlink. "
                                      "Remove it manually before installing.")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@
 // $DISPLAY, no libGL) the binary stays in CLI mode.
 //
 // macOS / Windows: the GUI runs inline below under #ifndef __linux__.
-// No dlopen, no plugin — the executable links Qt6::Widgets directly,
+// No dlopen, no plugin - the executable links Qt6::Widgets directly,
 // exactly as it always has.
 
 #include "clihandler.h"
@@ -26,18 +26,18 @@
 // Windows builds use the console subsystem so CLI subcommands (--help,
 // list, extract, ...) print reliably to any shell. The cost is that a
 // console window is allocated when launching from Explorer. Hide it (only
-// if we own the console — never the inherited terminal of cmd / PowerShell
+// if we own the console - never the inherited terminal of cmd / PowerShell
 // / Windows Terminal) and detach before the GUI event loop starts so the
 // GUI looks clean. No-op on macOS/Linux.
 static void detachFromConsole()
 {
 #ifdef Q_OS_WIN
     // GetWindowThreadProcessId(GetConsoleWindow(), ...) returns the PID of
-    // conhost.exe (the out-of-process console host), not our PID — so a
+    // conhost.exe (the out-of-process console host), not our PID - so a
     // self-ownership check is always false. The documented idiom is
     // GetConsoleProcessList: a count of 1 means we are the sole attachee,
     // i.e. Windows allocated this console for us at launch (Explorer flow).
-    // A count > 1 means we inherited the user's terminal — leave it alone.
+    // A count > 1 means we inherited the user's terminal - leave it alone.
     if (GetConsoleProcessList(nullptr, 0) == 1) {
         if (HWND console = GetConsoleWindow())
             ShowWindow(console, SW_HIDE);
@@ -175,7 +175,7 @@ static int runGuiPlugin(int argc, char **argv, bool loudOnFail)
 
 // Probe whether GUI mode is viable. Returns true and leaves whyOut
 // empty on success; returns false and writes a short reason on
-// failure. We dlclose what we open here — runGuiPlugin re-opens for
+// failure. We dlclose what we open here - runGuiPlugin re-opens for
 // the real run.
 static bool guiProbeOk(QString *whyOut)
 {
@@ -254,12 +254,12 @@ int main(int argc, char *argv[])
 
     // ── Subcommand dispatch (all platforms) ────────────────────────────────
     // Detect subcommand or --help/--version from raw argv BEFORE creating
-    // any Q*Application. CLI subcommands use QCoreApplication only — they
+    // any Q*Application. CLI subcommands use QCoreApplication only - they
     // never construct QApplication and never need a display server.
     if (argc >= 2) {
         const QString sub = QString::fromLocal8Bit(argv[1]);
 
-        // Global help — intercept before QApplication to prevent
+        // Global help - intercept before QApplication to prevent
         // QCommandLineParser's auto-help from showing the old GUI-mode help
         if (sub == "--help" || sub == "-h") {
             printGlobalHelp();
@@ -352,7 +352,7 @@ static int runGuiInline(int argc, char **argv)
         QDir extractTo(destination + "/" + fileInfo.baseName());
         // mkpath() returns true when the directory already exists, so on
         // error paths we must only removeRecursively() the dir if WE created
-        // it — otherwise we'd silently wipe a user's pre-existing directory
+        // it - otherwise we'd silently wipe a user's pre-existing directory
         // (e.g. a prior successful extraction at the same destination).
         const bool dirPreExisted = QFileInfo::exists(extractTo.path());
         if (!QDir().mkpath(extractTo.path())) {
@@ -429,7 +429,7 @@ static int runGuiInline(int argc, char **argv)
         return 0;
     }
 
-    // Past the CLI-only paths — we're going to QApplication::exec() one way
+    // Past the CLI-only paths - we're going to QApplication::exec() one way
     // or another (auto-extract, GUI with --source, or bare GUI). On Windows,
     // drop the console window allocated for the console-subsystem binary so
     // the GUI launch doesn't leave an empty cmd window behind.

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -46,7 +46,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     QAction *uninstallAction = toolsMenu->addAction(tr("Uninstall Traktor..."));
     connect(uninstallAction, &QAction::triggered, this, &MainWindow::uninstallTraktor);
 
-    // "About Traktor" — universal across platforms.
+    // "About Traktor" - universal across platforms.
     // setMenuRole(AboutRole) routes this into the macOS app menu's About
     // slot; on Windows/Linux it stays in the Tools menu where added.
     QAction *aboutAction = new QAction(tr("About Traktor"), this);
@@ -58,19 +58,19 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     });
 
 #ifdef Q_OS_MAC
-    // Sparkle auto-update bridge — macOS only for now (WinSparkle is a
+    // Sparkle auto-update bridge - macOS only for now (WinSparkle is a
     // separate workstream). Construction starts Sparkle's scheduled check
     // loop, reading SUFeedURL and SUPublicEDKey from Info.plist.
     m_updateManager = new UpdateManager(this);
 
-    // "Check for Updates..." — setMenuRole(ApplicationSpecificRole) tells
+    // "Check for Updates..." - setMenuRole(ApplicationSpecificRole) tells
     // Qt to relocate this into the macOS app menu (Traktor → ...) right
     // below the About item. We add it to the Tools menu but Qt moves it
     // out at runtime on macOS.
     //
-    // SPUStandardUpdaterController::checkForUpdates: is idempotent — if a
+    // SPUStandardUpdaterController::checkForUpdates: is idempotent - if a
     // check is already in flight it just re-fronts Sparkle's progress
-    // window — so we don't need to disable the action while busy.
+    // window - so we don't need to disable the action while busy.
     QAction *checkForUpdatesAction = new QAction(tr("Check for Updates..."), this);
     checkForUpdatesAction->setMenuRole(QAction::ApplicationSpecificRole);
     toolsMenu->addAction(checkForUpdatesAction);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -15,7 +15,12 @@
 #include "installcli.h"
 #include "passworddialog.h"
 #include "setupdialog.h"
+#include "aboutdialog.h"
 #include "cryptoutils.h"
+
+#ifdef Q_OS_MAC
+#include "updatemanager.h"
+#endif
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow)
 {
@@ -40,6 +45,38 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     toolsMenu->addSeparator();
     QAction *uninstallAction = toolsMenu->addAction(tr("Uninstall Traktor..."));
     connect(uninstallAction, &QAction::triggered, this, &MainWindow::uninstallTraktor);
+
+#ifdef Q_OS_MAC
+    // Sparkle auto-update bridge — macOS only for now (WinSparkle is a
+    // separate workstream). Construction starts Sparkle's scheduled check
+    // loop, reading SUFeedURL and SUPublicEDKey from Info.plist.
+    m_updateManager = new UpdateManager(this);
+
+    // "Check for Updates..." — setMenuRole(ApplicationSpecificRole) tells
+    // Qt to relocate this into the macOS app menu (Traktor → ...). We add
+    // it to the Tools menu but Qt moves it out at runtime on macOS.
+    QAction *checkForUpdatesAction = new QAction(tr("Check for Updates..."), this);
+    checkForUpdatesAction->setMenuRole(QAction::ApplicationSpecificRole);
+    toolsMenu->addAction(checkForUpdatesAction);
+    connect(checkForUpdatesAction, &QAction::triggered, m_updateManager, &UpdateManager::checkForUpdates);
+    checkForUpdatesAction->setEnabled(m_updateManager->canCheckForUpdates());
+    connect(m_updateManager, &UpdateManager::canCheckForUpdatesChanged, this, [this, checkForUpdatesAction] {
+        checkForUpdatesAction->setEnabled(m_updateManager->canCheckForUpdates());
+    });
+#endif
+
+    // "About Traktor" — universal across platforms.
+    // setMenuRole(AboutRole) routes this into the macOS app menu's About
+    // slot; on Windows/Linux it stays in the Tools menu where added.
+    // The dialog itself shows update controls only on macOS (where the
+    // m_updateManager pointer is non-null).
+    QAction *aboutAction = new QAction(tr("About Traktor"), this);
+    aboutAction->setMenuRole(QAction::AboutRole);
+    toolsMenu->addAction(aboutAction);
+    connect(aboutAction, &QAction::triggered, this, [this] {
+        AboutDialog dlg(m_updateManager, this);
+        dlg.exec();
+    });
 
     // First-run setup dialog
     QSettings firstRunSettings("com.servmask", "Traktor");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -46,6 +46,17 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     QAction *uninstallAction = toolsMenu->addAction(tr("Uninstall Traktor..."));
     connect(uninstallAction, &QAction::triggered, this, &MainWindow::uninstallTraktor);
 
+    // "About Traktor" — universal across platforms.
+    // setMenuRole(AboutRole) routes this into the macOS app menu's About
+    // slot; on Windows/Linux it stays in the Tools menu where added.
+    QAction *aboutAction = new QAction(tr("About Traktor"), this);
+    aboutAction->setMenuRole(QAction::AboutRole);
+    toolsMenu->addAction(aboutAction);
+    connect(aboutAction, &QAction::triggered, this, [this] {
+        AboutDialog dlg(this);
+        dlg.exec();
+    });
+
 #ifdef Q_OS_MAC
     // Sparkle auto-update bridge — macOS only for now (WinSparkle is a
     // separate workstream). Construction starts Sparkle's scheduled check
@@ -53,30 +64,18 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
     m_updateManager = new UpdateManager(this);
 
     // "Check for Updates..." — setMenuRole(ApplicationSpecificRole) tells
-    // Qt to relocate this into the macOS app menu (Traktor → ...). We add
-    // it to the Tools menu but Qt moves it out at runtime on macOS.
+    // Qt to relocate this into the macOS app menu (Traktor → ...) right
+    // below the About item. We add it to the Tools menu but Qt moves it
+    // out at runtime on macOS.
+    //
+    // SPUStandardUpdaterController::checkForUpdates: is idempotent — if a
+    // check is already in flight it just re-fronts Sparkle's progress
+    // window — so we don't need to disable the action while busy.
     QAction *checkForUpdatesAction = new QAction(tr("Check for Updates..."), this);
     checkForUpdatesAction->setMenuRole(QAction::ApplicationSpecificRole);
     toolsMenu->addAction(checkForUpdatesAction);
     connect(checkForUpdatesAction, &QAction::triggered, m_updateManager, &UpdateManager::checkForUpdates);
-    checkForUpdatesAction->setEnabled(m_updateManager->canCheckForUpdates());
-    connect(m_updateManager, &UpdateManager::canCheckForUpdatesChanged, this, [this, checkForUpdatesAction] {
-        checkForUpdatesAction->setEnabled(m_updateManager->canCheckForUpdates());
-    });
 #endif
-
-    // "About Traktor" — universal across platforms.
-    // setMenuRole(AboutRole) routes this into the macOS app menu's About
-    // slot; on Windows/Linux it stays in the Tools menu where added.
-    // The dialog itself shows update controls only on macOS (where the
-    // m_updateManager pointer is non-null).
-    QAction *aboutAction = new QAction(tr("About Traktor"), this);
-    aboutAction->setMenuRole(QAction::AboutRole);
-    toolsMenu->addAction(aboutAction);
-    connect(aboutAction, &QAction::triggered, this, [this] {
-        AboutDialog dlg(m_updateManager, this);
-        dlg.exec();
-    });
 
     // First-run setup dialog
     QSettings firstRunSettings("com.servmask", "Traktor");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,7 +1,9 @@
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
+#include <QApplication>
 #include <QFileDialog>
 #include <QIODevice>
+#include <QIcon>
 #include <QMenuBar>
 #include <QAction>
 #include <QMessageBox>
@@ -17,6 +19,11 @@
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWindow)
 {
+    // Set the app icon globally so QApplication::windowIcon() returns it
+    // for AboutDialog and any other window that asks. Bundled via the
+    // resources.qrc Qt resource so it works the same on all platforms.
+    qApp->setWindowIcon(QIcon(QStringLiteral(":/icons/traktor.png")));
+
     ui->setupUi(this);
     ui->progressBar->setVisible(false);
     ui->logTextEdit->setVisible(false);

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -12,6 +12,8 @@ namespace Ui
 class MainWindow;
 }
 
+class UpdateManager; // macOS-only; declared in src/updatemanager.h
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -42,6 +44,7 @@ private:
     QString currentExtractDir;
     QString lastExtractionError;
     ExtractionWorker *activeWorker = nullptr;
+    UpdateManager *m_updateManager = nullptr; // non-null only on macOS
     void showInGraphicalShell(const QString &pathIn);
 };
 

--- a/src/mcpserver.cpp
+++ b/src/mcpserver.cpp
@@ -421,7 +421,7 @@ static QJsonObject dispatch(const QJsonObject &request)
         return makeResponse(id, result);
     }
 
-    // Notifications have no id — don't respond
+    // Notifications have no id - don't respond
     if (method == "notifications/initialized") {
         return QJsonObject(); // empty = no response
     }
@@ -568,7 +568,7 @@ int cmdMcp()
         const QJsonObject request = doc.object();
         const QJsonObject response = dispatch(request);
 
-        // Notifications produce an empty response — don't send anything
+        // Notifications produce an empty response - don't send anything
         if (response.isEmpty()) {
             continue;
         }

--- a/src/mcpserver.h
+++ b/src/mcpserver.h
@@ -4,7 +4,7 @@
 // MCP (Model Context Protocol) server for Qtraktor.
 // Speaks JSON-RPC 2.0 over stdin/stdout per MCP spec 2025-11-25.
 // Exposes list, info, extract, cat, verify as typed MCP tools.
-// Runs as a synchronous blocking loop — no Qt event loop needed.
+// Runs as a synchronous blocking loop - no Qt event loop needed.
 
 int cmdMcp();
 

--- a/src/updatemanager.h
+++ b/src/updatemanager.h
@@ -7,44 +7,29 @@
 // Sparkle/Cocoa types from the rest of the codebase via a pimpl, so callers
 // can include this header without pulling in Sparkle.h or Obj-C.
 //
-// Threading: Sparkle invokes its callbacks on the main thread; all signals
-// emitted by this class fire on the main thread.
+// Threading: Sparkle invokes its callbacks on the main thread.
 //
 // Lifetime: instantiate once (typically owned by MainWindow). The Sparkle
-// updater starts checking on construction and runs for the app's lifetime.
+// updater starts its scheduled check loop on construction and runs for the
+// app's lifetime. Automatic checks are forced on at every launch — there
+// is no user-facing toggle by design.
 
 class UpdateManagerPrivate;
 
 class UpdateManager : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(bool canCheckForUpdates READ canCheckForUpdates NOTIFY canCheckForUpdatesChanged)
-    Q_PROPERTY(bool automaticallyChecksForUpdates READ automaticallyChecksForUpdates WRITE
-                   setAutomaticallyChecksForUpdates NOTIFY automaticallyChecksForUpdatesChanged)
 
 public:
     explicit UpdateManager(QObject *parent = nullptr);
     ~UpdateManager() override;
 
-    // True when an update check can be initiated. Bound to Sparkle's
-    // SPUUpdater.canCheckForUpdates; toggles to false while a check is
-    // already in flight. UI should disable the menu item / button when false.
-    bool canCheckForUpdates() const;
-
-    // Whether Sparkle automatically checks for updates on a schedule
-    // (default: on launch + every 24h). Backed by NSUserDefaults — flipping
-    // it persists across app restarts.
-    bool automaticallyChecksForUpdates() const;
-    void setAutomaticallyChecksForUpdates(bool enabled);
-
 public slots:
     // Triggers a user-visible update check. Sparkle shows its own progress
-    // and update-available dialogs; we don't need to render UI ourselves.
+    // and update-available dialogs; we don't render any UI ourselves. The
+    // call is idempotent — if a check is already in flight, Sparkle just
+    // re-fronts the existing window.
     void checkForUpdates();
-
-signals:
-    void canCheckForUpdatesChanged();
-    void automaticallyChecksForUpdatesChanged();
 
 private:
     UpdateManagerPrivate *d;

--- a/src/updatemanager.h
+++ b/src/updatemanager.h
@@ -11,7 +11,7 @@
 //
 // Lifetime: instantiate once (typically owned by MainWindow). The Sparkle
 // updater starts its scheduled check loop on construction and runs for the
-// app's lifetime. Automatic checks are forced on at every launch — there
+// app's lifetime. Automatic checks are forced on at every launch - there
 // is no user-facing toggle by design.
 
 class UpdateManagerPrivate;
@@ -27,7 +27,7 @@ public:
 public slots:
     // Triggers a user-visible update check. Sparkle shows its own progress
     // and update-available dialogs; we don't render any UI ourselves. The
-    // call is idempotent — if a check is already in flight, Sparkle just
+    // call is idempotent - if a check is already in flight, Sparkle just
     // re-fronts the existing window.
     void checkForUpdates();
 

--- a/src/updatemanager.h
+++ b/src/updatemanager.h
@@ -1,0 +1,53 @@
+#ifndef UPDATEMANAGER_H
+#define UPDATEMANAGER_H
+
+#include <QObject>
+
+// Qt-facing wrapper around Sparkle's SPUStandardUpdaterController. Hides
+// Sparkle/Cocoa types from the rest of the codebase via a pimpl, so callers
+// can include this header without pulling in Sparkle.h or Obj-C.
+//
+// Threading: Sparkle invokes its callbacks on the main thread; all signals
+// emitted by this class fire on the main thread.
+//
+// Lifetime: instantiate once (typically owned by MainWindow). The Sparkle
+// updater starts checking on construction and runs for the app's lifetime.
+
+class UpdateManagerPrivate;
+
+class UpdateManager : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool canCheckForUpdates READ canCheckForUpdates NOTIFY canCheckForUpdatesChanged)
+    Q_PROPERTY(bool automaticallyChecksForUpdates READ automaticallyChecksForUpdates WRITE
+                   setAutomaticallyChecksForUpdates NOTIFY automaticallyChecksForUpdatesChanged)
+
+public:
+    explicit UpdateManager(QObject *parent = nullptr);
+    ~UpdateManager() override;
+
+    // True when an update check can be initiated. Bound to Sparkle's
+    // SPUUpdater.canCheckForUpdates; toggles to false while a check is
+    // already in flight. UI should disable the menu item / button when false.
+    bool canCheckForUpdates() const;
+
+    // Whether Sparkle automatically checks for updates on a schedule
+    // (default: on launch + every 24h). Backed by NSUserDefaults — flipping
+    // it persists across app restarts.
+    bool automaticallyChecksForUpdates() const;
+    void setAutomaticallyChecksForUpdates(bool enabled);
+
+public slots:
+    // Triggers a user-visible update check. Sparkle shows its own progress
+    // and update-available dialogs; we don't need to render UI ourselves.
+    void checkForUpdates();
+
+signals:
+    void canCheckForUpdatesChanged();
+    void automaticallyChecksForUpdatesChanged();
+
+private:
+    UpdateManagerPrivate *d;
+};
+
+#endif // UPDATEMANAGER_H

--- a/src/updatemanager.mm
+++ b/src/updatemanager.mm
@@ -1,0 +1,91 @@
+#include "updatemanager.h"
+
+#import <Sparkle/Sparkle.h>
+
+// Obj-C observer that forwards Sparkle's KVO notifications to UpdateManager.
+// Holds a non-owning pointer to its Qt owner; UpdateManager removes us as a
+// KVO observer in its destructor before we get released, so we never dangle.
+@interface SparkleUpdateObserver : NSObject {
+@public
+    UpdateManager *qtOwner;
+}
+@end
+
+@implementation SparkleUpdateObserver
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSKeyValueChangeKey, id> *)change
+                       context:(void *)context
+{
+    Q_UNUSED(object);
+    Q_UNUSED(change);
+    Q_UNUSED(context);
+
+    if ([keyPath isEqualToString:@"canCheckForUpdates"]) {
+        Q_EMIT qtOwner->canCheckForUpdatesChanged();
+    } else if ([keyPath isEqualToString:@"automaticallyChecksForUpdates"]) {
+        Q_EMIT qtOwner->automaticallyChecksForUpdatesChanged();
+    }
+}
+@end
+
+// pimpl — owns the Sparkle controller and our KVO observer. Defined in the
+// .mm so the header can stay Sparkle-free.
+class UpdateManagerPrivate
+{
+public:
+    SPUStandardUpdaterController *controller = nil;
+    SparkleUpdateObserver *observer = nil;
+};
+
+UpdateManager::UpdateManager(QObject *parent)
+    : QObject(parent), d(new UpdateManagerPrivate)
+{
+    // startingUpdater:YES kicks off the scheduled check loop immediately.
+    // Sparkle reads SUFeedURL and SUPublicEDKey from the bundle's Info.plist.
+    d->controller = [[SPUStandardUpdaterController alloc]
+        initWithStartingUpdater:YES
+                updaterDelegate:nil
+             userDriverDelegate:nil];
+
+    d->observer = [[SparkleUpdateObserver alloc] init];
+    d->observer->qtOwner = this;
+
+    SPUUpdater *updater = d->controller.updater;
+    [updater addObserver:d->observer
+              forKeyPath:@"canCheckForUpdates"
+                 options:NSKeyValueObservingOptionNew
+                 context:nullptr];
+    [updater addObserver:d->observer
+              forKeyPath:@"automaticallyChecksForUpdates"
+                 options:NSKeyValueObservingOptionNew
+                 context:nullptr];
+}
+
+UpdateManager::~UpdateManager()
+{
+    SPUUpdater *updater = d->controller.updater;
+    [updater removeObserver:d->observer forKeyPath:@"canCheckForUpdates"];
+    [updater removeObserver:d->observer forKeyPath:@"automaticallyChecksForUpdates"];
+    delete d;
+}
+
+bool UpdateManager::canCheckForUpdates() const
+{
+    return d->controller.updater.canCheckForUpdates;
+}
+
+bool UpdateManager::automaticallyChecksForUpdates() const
+{
+    return d->controller.updater.automaticallyChecksForUpdates;
+}
+
+void UpdateManager::setAutomaticallyChecksForUpdates(bool enabled)
+{
+    d->controller.updater.automaticallyChecksForUpdates = enabled ? YES : NO;
+}
+
+void UpdateManager::checkForUpdates()
+{
+    [d->controller checkForUpdates:nil];
+}

--- a/src/updatemanager.mm
+++ b/src/updatemanager.mm
@@ -2,87 +2,32 @@
 
 #import <Sparkle/Sparkle.h>
 
-// Obj-C observer that forwards Sparkle's KVO notifications to UpdateManager.
-// Holds a non-owning pointer to its Qt owner; UpdateManager removes us as a
-// KVO observer in its destructor before we get released, so we never dangle.
-@interface SparkleUpdateObserver : NSObject {
-@public
-    UpdateManager *qtOwner;
-}
-@end
-
-@implementation SparkleUpdateObserver
-- (void)observeValueForKeyPath:(NSString *)keyPath
-                      ofObject:(id)object
-                        change:(NSDictionary<NSKeyValueChangeKey, id> *)change
-                       context:(void *)context
-{
-    Q_UNUSED(object);
-    Q_UNUSED(change);
-    Q_UNUSED(context);
-
-    if ([keyPath isEqualToString:@"canCheckForUpdates"]) {
-        Q_EMIT qtOwner->canCheckForUpdatesChanged();
-    } else if ([keyPath isEqualToString:@"automaticallyChecksForUpdates"]) {
-        Q_EMIT qtOwner->automaticallyChecksForUpdatesChanged();
-    }
-}
-@end
-
-// pimpl — owns the Sparkle controller and our KVO observer. Defined in the
-// .mm so the header can stay Sparkle-free.
+// pimpl — owns the Sparkle controller. Defined in the .mm so the header can
+// stay Sparkle-free.
 class UpdateManagerPrivate
 {
 public:
     SPUStandardUpdaterController *controller = nil;
-    SparkleUpdateObserver *observer = nil;
 };
 
-UpdateManager::UpdateManager(QObject *parent)
-    : QObject(parent), d(new UpdateManagerPrivate)
+UpdateManager::UpdateManager(QObject *parent) : QObject(parent), d(new UpdateManagerPrivate)
 {
     // startingUpdater:YES kicks off the scheduled check loop immediately.
     // Sparkle reads SUFeedURL and SUPublicEDKey from the bundle's Info.plist.
-    d->controller = [[SPUStandardUpdaterController alloc]
-        initWithStartingUpdater:YES
-                updaterDelegate:nil
-             userDriverDelegate:nil];
+    d->controller = [[SPUStandardUpdaterController alloc] initWithStartingUpdater:YES
+                                                                  updaterDelegate:nil
+                                                               userDriverDelegate:nil];
 
-    d->observer = [[SparkleUpdateObserver alloc] init];
-    d->observer->qtOwner = this;
-
-    SPUUpdater *updater = d->controller.updater;
-    [updater addObserver:d->observer
-              forKeyPath:@"canCheckForUpdates"
-                 options:NSKeyValueObservingOptionNew
-                 context:nullptr];
-    [updater addObserver:d->observer
-              forKeyPath:@"automaticallyChecksForUpdates"
-                 options:NSKeyValueObservingOptionNew
-                 context:nullptr];
+    // Force automatic checks on every launch. Info.plist already sets
+    // SUEnableAutomaticChecks=YES so Sparkle won't prompt the user, but we
+    // also re-assert the runtime flag so a stale `defaults write` cannot
+    // disable updates. There is no user-facing toggle by design.
+    d->controller.updater.automaticallyChecksForUpdates = YES;
 }
 
 UpdateManager::~UpdateManager()
 {
-    SPUUpdater *updater = d->controller.updater;
-    [updater removeObserver:d->observer forKeyPath:@"canCheckForUpdates"];
-    [updater removeObserver:d->observer forKeyPath:@"automaticallyChecksForUpdates"];
     delete d;
-}
-
-bool UpdateManager::canCheckForUpdates() const
-{
-    return d->controller.updater.canCheckForUpdates;
-}
-
-bool UpdateManager::automaticallyChecksForUpdates() const
-{
-    return d->controller.updater.automaticallyChecksForUpdates;
-}
-
-void UpdateManager::setAutomaticallyChecksForUpdates(bool enabled)
-{
-    d->controller.updater.automaticallyChecksForUpdates = enabled ? YES : NO;
 }
 
 void UpdateManager::checkForUpdates()

--- a/src/updatemanager.mm
+++ b/src/updatemanager.mm
@@ -2,7 +2,7 @@
 
 #import <Sparkle/Sparkle.h>
 
-// pimpl — owns the Sparkle controller. Defined in the .mm so the header can
+// pimpl - owns the Sparkle controller. Defined in the .mm so the header can
 // stay Sparkle-free.
 class UpdateManagerPrivate
 {

--- a/tests/tst_cli.cpp
+++ b/tests/tst_cli.cpp
@@ -378,7 +378,7 @@ private slots:
 
     void testMcpVerifyV1Unchecked()
     {
-        // v1 archives have no CRC — MCP verify should report "unchecked"
+        // v1 archives have no CRC - MCP verify should report "unchecked"
         BackupFile *bf = openFixture("plain.wpress");
         QVERIFY(bf != nullptr);
 
@@ -528,7 +528,7 @@ private slots:
         f.write("not valid json {{{");
         f.close();
 
-        // Try to parse — should fail
+        // Try to parse - should fail
         QVERIFY(f.open(QIODevice::ReadOnly));
         QJsonParseError parseErr;
         QJsonDocument::fromJson(f.readAll(), &parseErr);
@@ -700,7 +700,7 @@ private slots:
         QVERIFY(tmpDir.isValid());
         AgentConfigManager mgr(tmpDir.path());
 
-        // Gemini config is in ~/.gemini/settings.json — directory doesn't exist yet
+        // Gemini config is in ~/.gemini/settings.json - directory doesn't exist yet
         bool ok = mgr.registerAgent(AGENT_GEMINI);
         QVERIFY(ok);
         QVERIFY(QFile::exists(tmpDir.path() + "/.gemini/settings.json"));

--- a/tests/tst_fuzz.cpp
+++ b/tests/tst_fuzz.cpp
@@ -327,7 +327,7 @@ private slots:
 
     void testMissingConfigFile()
     {
-        // Archive with no package.json — goes straight to data files
+        // Archive with no package.json - goes straight to data files
         QByteArray data;
         data.append(makeHeader("file.txt", 5));
         data.append("hello");


### PR DESCRIPTION
## Summary

Adds in-app auto-update for macOS via Sparkle 2. Once this lands, every signed release ships `Traktor.app.zip` + `appcast-macos.xml` as release assets; users on this version or later get an "About Traktor" entry plus "Check for Updates..." in the macOS app menu, with auto-check on by default (one prompt per 24h).

## What's in

- **Vendor `Sparkle.framework` 2.9.1** via CMake `FetchContent`. POST_BUILD step copies it into `Contents/Frameworks/` (preserving Sparkle's symlinks via `ditto` — `cmake -E copy_directory` flattens them and breaks codesign).
- **`UpdateManager` Obj-C++ bridge** — wraps `SPUStandardUpdaterController` behind a Qt-friendly API with `Q_PROPERTY` for `canCheckForUpdates` and `automaticallyChecksForUpdates`. Pimpl keeps Sparkle headers out of the public Qt-facing class.
- **`AboutDialog`** — new cross-platform dialog (icon, name, version, tagline link, copyright). On macOS, adds "Check for Updates..." button + "Automatically check for updates" checkbox bound two-way to Sparkle's NSUserDefaults-backed property.
- **MainWindow menu wiring** — "About Traktor" (universal, via `QAction::AboutRole`) + "Check for Updates..." (macOS only, via `ApplicationSpecificRole`). Both get auto-relocated into the macOS app menu by Qt.
- **`Info.plist.in` additions**: `SUFeedURL`, `SUPublicEDKey`, `SUEnableAutomaticChecks=true`, `CFBundleShortVersionString`, `CFBundleVersion` (Sparkle requires both bundle version keys to start).
- **`release.yml` additions**:
  - Signs Sparkle's nested helper bundles (`Updater.app`, `Autoupdate`, `XPCServices/{Downloader,Installer}.xpc`) with our Developer ID before the framework wrapper — Apple notarization rejects the bundle without this.
  - Sparkle artifact step: zip the stapled `.app`, EdDSA-sign via `sign_update`, render `appcast-macos.xml` from a template, upload as workflow artifacts + release assets.
  - Single up-front sparse-checkout (`scripts/macos-pkg` + `scripts/sparkle`); drops the previous "rename app before checkout" workaround.
  - `PROJECT_VERSION_STR` also defined on `traktor-gui` (Linux GUI library), since `aboutdialog.cpp` lives there in the hybrid CLI/GUI split.

Stable feed URL embedded in `Info.plist`: `https://github.com/servmask/Qtraktor/releases/latest/download/appcast-macos.xml`

## Dependencies

- **Stacks on #45** (entitlements file with `allow-jit`). The bottom commit on this branch is the same change as #45; once #45 merges, rebasing this branch on master drops the duplicate cleanly.

## Test plan

- [x] `workflow_dispatch` end-to-end: build → codesign (with new Sparkle nested-bundle signing) → notarize + staple `.app` → render signed appcast → upload artifacts. Apple notary accepts the bundle.
- [x] Local runtime: Sparkle bootstraps without error, "Check for Updates..." enables correctly, auto-check checkbox reflects `SUEnableAutomaticChecks=true`.
- [x] Sparkle URL → fetch → parse → version-compare round-trip validated end-to-end against the production `releases/latest/download/` URL pattern.
- [ ] Post-merge first release: confirm `appcast-macos.xml` + `Traktor.app.zip` ship as release assets via the gated `upload` job.
- [ ] Subsequent release: existing users see the auto-update prompt and the install path completes (downloads → replaces `.app` → relaunches).

## Notes

- macOS-only for now. Windows (WinSparkle) is a follow-on workstream — same EdDSA key, same appcast URL pattern, simpler C-API integration.
- The first Sparkle-enabled release will check the appcast and find itself as latest → "you're up to date" until the subsequent release ships, which is when users actually start seeing prompts.