### PR TITLE
fix(windows): hide console window on GUI launch from Explorer

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,13 +32,13 @@
 static void detachFromConsole()
 {
 #ifdef Q_OS_WIN
-    // GetWindowThreadProcessId(GetConsoleWindow(), ...) returns the PID of
-    // conhost.exe (the out-of-process console host), not our PID - so a
-    // self-ownership check is always false. The documented idiom is
-    // GetConsoleProcessList: a count of 1 means we are the sole attachee,
-    // i.e. Windows allocated this console for us at launch (Explorer flow).
-    // A count > 1 means we inherited the user's terminal - leave it alone.
-    if (GetConsoleProcessList(nullptr, 0) == 1) {
+    // GetConsoleProcessList returns the number of processes attached to this
+    // console. A count of 1 means we are the sole attachee - Windows allocated
+    // the console for us at launch (Explorer / double-click flow). A count > 1
+    // means we inherited the user's terminal - leave it alone.
+    // NOTE: must pass a valid (non-null) buffer; passing nullptr returns 0 (fail).
+    DWORD pids[2];
+    if (GetConsoleProcessList(pids, 2) == 1) {
         if (HWND console = GetConsoleWindow())
             ShowWindow(console, SW_HIDE);
         FreeConsole();
@@ -234,6 +234,13 @@ static int runCliFallback(int argc, char **argv)
 
 int main(int argc, char *argv[])
 {
+#ifdef Q_OS_WIN
+    // No arguments = definitely a GUI launch (double-click / file association
+    // handled later). Hide the console immediately so it never flashes on screen.
+    if (argc == 1)
+        detachFromConsole();
+#endif
+
 #ifdef __linux__
     // Detect and strip Linux GUI/CLI flags BEFORE the all-platforms subcommand
     // dispatch so:


### PR DESCRIPTION
## What does this PR do?

  Fixes a bug where a black console window would remain visible in the background
  when launching Traktor by double-clicking from Explorer.

  The root cause was `GetConsoleProcessList(nullptr, 0)` in `detachFromConsole()` —
  passing a null pointer causes the Windows API to return 0 (failure), so the
  condition `== 1` was never true and the console window was never hidden or freed.

  Two changes in `src/main.cpp`:
  - Pass a valid buffer to `GetConsoleProcessList` so the sole-attachee check works correctly
  - Call `detachFromConsole()` at the top of `main()` when `argc == 1` (guaranteed GUI launch via Explorer) to eliminate
   any console flash before Qt initializes

  ## Related Issue

  <!-- Link to the issue this PR addresses, e.g., Fixes #123 -->

  ## Checklist

  - [x] PR title follows conventional commit format (`feat:`, `fix:`, `docs:`, etc.)
  - [x] Code compiles without warnings on at least one platform
  - [x] Tests pass locally (`cmake -B build && cmake --build build && cd build && ctest --output-on-failure`)
  - [x] New code follows existing style (run `clang-format -i` on changed files)
  - [ ] Added tests for new functionality (if applicable)

  ## Screenshots / Output

  **Before:** launching `Traktor.exe` from Explorer showed the GUI with a black console window lingering in the
  background (visible in taskbar and alt-tab).

  **After:** GUI launches cleanly with no console window.