### PR TITLE
ci: pin macOS runners to macos-15 to fix AGL link failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,10 @@ jobs:
 
   build-test-macos:
     name: Build & Test (macOS)
-    runs-on: macos-latest
+    # Pinned to macos-15 (Sequoia): macos-latest moved to macOS 26 (Tahoe),
+    # whose SDK dropped the legacy AGL framework that Qt 6.8's CMake config
+    # still links via Qt6::Gui, causing "ld: framework 'AGL' not found".
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: macos-latest
+          # Pinned to macos-15 (Sequoia): macos-latest moved to macOS 26
+          # (Tahoe), whose SDK dropped the legacy AGL framework that Qt 6.8's
+          # CMake config still links via Qt6::Gui ("ld: framework 'AGL' not
+          # found"). macos-15-intel is the x86_64 counterpart.
+          - runner: macos-15
             arch: arm64
           - runner: macos-15-intel
             arch: x86_64
@@ -86,7 +90,9 @@ jobs:
 
   package-macos:
     needs: build-macos
-    runs-on: macos-latest
+    # Pinned to macos-15 (Sequoia) for parity with the build job; avoids the
+    # macOS 26 (Tahoe) toolchain on the codesign/notarize/pkgbuild path.
+    runs-on: macos-15
     steps:
       # Sparse checkout up-front: scripts/macos-pkg/ has entitlements.plist
       # (codesign step) and pkgbuild scripts/resources (PKG step);


### PR DESCRIPTION
## Summary

The `macos-latest` GitHub runner image has rolled to **macOS 26 (Tahoe)**, whose SDK **removed the legacy AGL framework**. Qt 6.8's CMake config still emits `-framework AGL` for `Qt6::Gui`, so every macOS build now fails at link time:

```
ld: framework 'AGL' not found
clang++: error: linker command failed with exit code 1
```

This is a toolchain/runner regression unrelated to any source change — it currently breaks macOS CI on **all** PRs (e.g. #57). Same failure is being reported across other Qt/OpenGL projects (sioyek, wxWidgets) on Tahoe.

## Fix

Pin every `macos-latest` reference to **`macos-15`** (Sequoia, arm64), which still ships AGL. This matches:
- the existing `macos-15-intel` matrix entry in `release.yml`, and
- the project's pin-everything runner convention (`ubuntu-22.04`, `windows-2022`).

Affected jobs:
- `build-test-macos` — `ci.yml`
- `build-macos` (arm64 matrix leg) — `release.yml`
- `package-macos` — `release.yml`

No source or build-logic changes; CI configuration only.
